### PR TITLE
[TECHNICAL-SUPPORT] LPS-58900 The MANAGE_EVENTS permission allows the user to delete (and edit) a calendar event

### DIFF
--- a/modules/apps/calendar/calendar-service/src/com/liferay/calendar/service/impl/CalendarBookingServiceImpl.java
+++ b/modules/apps/calendar/calendar-service/src/com/liferay/calendar/service/impl/CalendarBookingServiceImpl.java
@@ -129,6 +129,10 @@ public class CalendarBookingServiceImpl extends CalendarBookingServiceBaseImpl {
 			getPermissionChecker(), calendarBooking.getCalendarId(),
 			CalendarActionKeys.MANAGE_BOOKINGS);
 
+		CalendarPermission.check(
+			getPermissionChecker(), calendarBooking.getCalendarId(),
+			ActionKeys.DELETE);
+
 		return calendarBookingLocalService.deleteCalendarBooking(
 			calendarBookingId);
 	}
@@ -144,6 +148,10 @@ public class CalendarBookingServiceImpl extends CalendarBookingServiceBaseImpl {
 		CalendarPermission.check(
 			getPermissionChecker(), calendarBooking.getCalendarId(),
 			CalendarActionKeys.MANAGE_BOOKINGS);
+
+		CalendarPermission.check(
+			getPermissionChecker(), calendarBooking.getCalendarId(),
+			ActionKeys.DELETE);
 
 		calendarBookingLocalService.deleteCalendarBookingInstance(
 			calendarBookingId, startTime, allFollowing);

--- a/modules/apps/calendar/calendar-web/src/META-INF/resources/js/javascript.js
+++ b/modules/apps/calendar/calendar-web/src/META-INF/resources/js/javascript.js
@@ -2103,7 +2103,7 @@ AUI.add(
 					},
 
 					_hasDeleteButton: function(permissions, calendar, status) {
-						return permissions.MANAGE_BOOKINGS && calendar;
+						return permissions.MANAGE_BOOKINGS && permissions.DELETE && calendar;
 					},
 
 					_hasEditButton: function(permissions, calendar, status) {


### PR DESCRIPTION
Hi Adam,

Could you please check this pull request?

This checks for the DELETE permission besides the MANAGE_BOOKINGS permission before rendering the Delete button, and also during the process of deleting a Calendar Booking.

Thank you.

Cheers,
István
