### PR TITLE
LPS-54715 Date interval check should be inclusive

### DIFF
--- a/modules/apps/calendar/calendar-web/src/META-INF/resources/view_calendar.jsp
+++ b/modules/apps/calendar/calendar-web/src/META-INF/resources/view_calendar.jsp
@@ -386,7 +386,7 @@ boolean columnOptionsVisible = GetterUtil.getBoolean(SessionClicks.get(request, 
 
 		var todayDate = <portlet:namespace />scheduler.get('todayDate');
 
-		if ((selectedDates.length > 0) && DateMath.between(todayDate, selectedDates[0], selectedDates[total - 1])) {
+		if ((selectedDates.length > 0) && ((todayDate >= selectedDates[0]) && (todayDate <= selectedDates[total - 1]))) {
 			viewDate = todayDate;
 		}
 


### PR DESCRIPTION
Hi Adam,

I had to reopen LPS-54715 and make some adjustments of the range check.
Because DateMath.between(todayDate, selectedDates[0], selectedDates[total - 1])) is not inclusive, it will return false of todayDate is the same as selectedDates[total - 1].

I changed the condition to include the boundary dates.

Could you please have a look at it?

Thank you!

Cheers,
István
