### PR TITLE
LPS-59497 Adding the default Calendar Resource in user personal pages…

### DIFF
--- a/modules/apps/calendar/calendar-service/src/main/java/com/liferay/calendar/util/CalendarResourceUtil.java
+++ b/modules/apps/calendar/calendar-service/src/main/java/com/liferay/calendar/util/CalendarResourceUtil.java
@@ -80,10 +80,6 @@ public class CalendarResourceUtil {
 
 		Group group = GroupLocalServiceUtil.getGroup(groupId);
 
-		if (group.isUser()) {
-			return null;
-		}
-
 		CalendarResource calendarResource =
 			CalendarResourceLocalServiceUtil.fetchCalendarResource(
 				PortalUtil.getClassNameId(Group.class), groupId);


### PR DESCRIPTION
… enables the Site Calendars menu and displays the default calendar

Hi Adam,

Jose passed me this, I think It's correct. The only issue is the calendar name: the user-level calendar will have the same name as the site-level. Anyway, we believe this should be solved at the UI level, not by renaming the calendar.

Please let me know!
Thanks