### PR TITLE
[TECHNICAL-SUPPORT] LPS-61389 Events on certain dates are not marked on the mini-calendar

### DIFF
--- a/modules/apps/calendar/calendar-web/src/main/resources/META-INF/resources/view_calendar.jsp
+++ b/modules/apps/calendar/calendar-web/src/main/resources/META-INF/resources/view_calendar.jsp
@@ -406,7 +406,7 @@ boolean columnOptionsVisible = GetterUtil.getBoolean(SessionClicks.get(request, 
 	window.<portlet:namespace />refreshVisibleCalendarRenderingRules = function() {
 		var miniCalendarStartDate = DateMath.subtract(DateMath.toMidnight(window.<portlet:namespace />miniCalendar.get('date')), DateMath.WEEK, 1);
 
-		var miniCalendarEndDate = DateMath.add(DateMath.add(miniCalendarStartDate, DateMath.MONTH, 1), DateMath.WEEK, 1);
+		var miniCalendarEndDate = DateMath.add(DateMath.add(window.<portlet:namespace />miniCalendar.get('date'), DateMath.MONTH, 1), DateMath.WEEK, 1);
 
 		miniCalendarEndDate.setHours(23, 59, 59, 999);
 


### PR DESCRIPTION
Hey Adam,

Could you please review this pull?

Because of the calculation method of minicalendar date ranges, there are some days which will not be marked when events are arranged on these days.

For example, if you create events for 2015 March 29, 30 and 31, only March 29 will be marked with the lfr-busy-day CSS class in the mini calendar.

This is because March 30 and 31 will fall out of the date range of consideration.
The date range is calculated as follows:

start date = (first day in the month in minicalendar) - (one week)
end date = (start date) + (one month) + (one week)

Therefore, if we consider the month of March, 2015.

first day in the month in minicalendar = March 1
start date = (March 1) - (one week) = February 22
end date = (February 22) + (one month) + (one week) = March 29

So March 30 and 31 will be out of range!.

The code which does this calculation is in view_calendar.jsp

```
var miniCalendarStartDate = DateMath.subtract(DateMath.toMidnight(window.<portlet:namespace />miniCalendar.get('date')), DateMath.WEEK, 1);

var miniCalendarEndDate = DateMath.add(DateMath.add(miniCalendarStartDate, DateMath.MONTH, 1), DateMath.WEEK, 1);
```

I modified it to take not miniCalendarStartDate, but the first day in the month as a base in the second formula, So in case of March, both 30 and 31 will be included in the range.

According to my tests, it works well, and hasn't produced any errors.

Thank you if you take a look at it.

Best regards,
István
