### PR TITLE
[TECHNICAL-SUPPORT] LPS-62069 Moving a recurring event to another date results the first event be placed to the wrong week

### DIFF
--- a/modules/apps/calendar/calendar-web/src/main/java/com/liferay/calendar/web/portlet/CalendarPortlet.java
+++ b/modules/apps/calendar/calendar-web/src/main/java/com/liferay/calendar/web/portlet/CalendarPortlet.java
@@ -646,6 +646,22 @@ public class CalendarPortlet extends MVCPortlet {
 			calendarBooking.setRecurrence(
 				RecurrenceSerializer.serialize(recurrenceObj));
 
+			java.util.Calendar firstDayJCalendar = JCalendarUtil.getJCalendar(
+				calendarBooking.getStartTime(), timeZone);
+
+			firstDayJCalendar.set(
+				java.util.Calendar.DAY_OF_WEEK_IN_MONTH,
+				startTimeJCalendar.get(
+					java.util.Calendar.DAY_OF_WEEK_IN_MONTH));
+
+			firstDayJCalendar.set(java.util.Calendar.DAY_OF_WEEK, 7);
+
+			calendarBooking.setEndTime(
+				firstDayJCalendar.getTimeInMillis() +
+				calendarBooking.getDuration());
+
+			calendarBooking.setStartTime(firstDayJCalendar.getTimeInMillis());
+
 			calendarBooking = RecurrenceUtil.getCalendarBookingInstance(
 				calendarBooking, 1);
 		}
@@ -1417,10 +1433,11 @@ public class CalendarPortlet extends MVCPortlet {
 				long duration = endTime - startTime;
 				long offset = getOffset(calendarBooking, startTime, recurrence);
 
-				calendarBooking =
-					_calendarBookingService.
-						getNewStartTimeAndDurationCalendarBooking(
-							calendarBookingId, offset, duration);
+				calendarBooking = CalendarUtil.getNewStartTimeCalendarBooking(
+					calendarBooking, offset);
+
+				calendarBooking = CalendarUtil.getNewDurationCalendarBooking(
+					calendarBooking, duration);
 
 				calendarBooking = getFirstCalendarBookingInstance(
 					calendarBooking, recurrence, timeZone);


### PR DESCRIPTION
Hey Adam,

I discovered that when I move a weekly recurring event in the calendar, in some cases the first instance will be placed to the wrong week.

There are two cases where this is apparent.
1. I create a recurring event on Tuesdays. then I move the first event backwards one day, from Tuesday to Monday. The series will start on Monday, but on the next week.
2. I create a recurring event on Tuesdays and Fridays, then I move the second event in the Friday column one day forward, to Saturday. Now, the second column will start on the previous week. ergo, the first instance of the whole series will be at Saturday, on the previous week.

Each of the two scenarios above are caused for different reasons.

(1) is because in CalendarPortlet.getFirstCalendarBookingInstance() 

```
calendarBooking = RecurrenceUtil.getCalendarBookingInstance(
                calendarBooking, 1);
```

will start the iteration from Tuesday, the day of the calendarBooking before the movement. Because Monday is behind Tuesday, and the iteration advances forward, the new day in the recurrence rule which the iteration hits will be Monday the next week.  So, there first instance will be on that day.

(2) is because the offset calculated by CalendarPortlet.getOffset() is applied to the very first instance of the series, instead to the instance being moved, therefore the iteration in getFirstCalendarBookingInstance() will start the week before the original event instance.  
If the instance of the 2nd week is moved, the offset  will shift the first instance by 1 week backwards. If the event on the 3rd week is moved, the offset shifts the first event 2 week backwards, and so on.

For (1), I modified getFirstCalendarBookingInstance() that the iteration starts from the last day of the week, but remains in the current week. The reason why it starts from the last day because when it would start on the first day, an instance placed to the first day would be missed by the iteration, and the first instance the iteration finds would be on the first day of the NEXT week.

I solved (2) by applying the offset and the duration on the moved instance, instead of the original first one, so the iteration will always start on the week of the original event.

Best regards,
István
