### PR TITLE
LPS-62735

### DIFF
--- a/modules/apps/forms-and-workflow/calendar/calendar-api/src/main/java/com/liferay/calendar/model/CalendarBookingModel.java
+++ b/modules/apps/forms-and-workflow/calendar/calendar-api/src/main/java/com/liferay/calendar/model/CalendarBookingModel.java
@@ -277,6 +277,20 @@ public interface CalendarBookingModel extends BaseModel<CalendarBooking>,
 	public void setParentCalendarBookingId(long parentCalendarBookingId);
 
 	/**
+	 * Returns the recurring calendar booking ID of this calendar booking.
+	 *
+	 * @return the recurring calendar booking ID of this calendar booking
+	 */
+	public long getRecurringCalendarBookingId();
+
+	/**
+	 * Sets the recurring calendar booking ID of this calendar booking.
+	 *
+	 * @param recurringCalendarBookingId the recurring calendar booking ID of this calendar booking
+	 */
+	public void setRecurringCalendarBookingId(long recurringCalendarBookingId);
+
+	/**
 	 * Returns the v event uid of this calendar booking.
 	 *
 	 * @return the v event uid of this calendar booking

--- a/modules/apps/forms-and-workflow/calendar/calendar-api/src/main/java/com/liferay/calendar/model/CalendarBookingSoap.java
+++ b/modules/apps/forms-and-workflow/calendar/calendar-api/src/main/java/com/liferay/calendar/model/CalendarBookingSoap.java
@@ -46,6 +46,7 @@ public class CalendarBookingSoap implements Serializable {
 		soapModel.setCalendarId(model.getCalendarId());
 		soapModel.setCalendarResourceId(model.getCalendarResourceId());
 		soapModel.setParentCalendarBookingId(model.getParentCalendarBookingId());
+		soapModel.setRecurringCalendarBookingId(model.getRecurringCalendarBookingId());
 		soapModel.setVEventUid(model.getVEventUid());
 		soapModel.setTitle(model.getTitle());
 		soapModel.setDescription(model.getDescription());
@@ -213,6 +214,14 @@ public class CalendarBookingSoap implements Serializable {
 		_parentCalendarBookingId = parentCalendarBookingId;
 	}
 
+	public long getRecurringCalendarBookingId() {
+		return _recurringCalendarBookingId;
+	}
+
+	public void setRecurringCalendarBookingId(long recurringCalendarBookingId) {
+		_recurringCalendarBookingId = recurringCalendarBookingId;
+	}
+
 	public String getVEventUid() {
 		return _vEventUid;
 	}
@@ -365,6 +374,7 @@ public class CalendarBookingSoap implements Serializable {
 	private long _calendarId;
 	private long _calendarResourceId;
 	private long _parentCalendarBookingId;
+	private long _recurringCalendarBookingId;
 	private String _vEventUid;
 	private String _title;
 	private String _description;

--- a/modules/apps/forms-and-workflow/calendar/calendar-api/src/main/java/com/liferay/calendar/model/CalendarBookingWrapper.java
+++ b/modules/apps/forms-and-workflow/calendar/calendar-api/src/main/java/com/liferay/calendar/model/CalendarBookingWrapper.java
@@ -72,6 +72,8 @@ public class CalendarBookingWrapper implements CalendarBooking,
 		attributes.put("calendarId", getCalendarId());
 		attributes.put("calendarResourceId", getCalendarResourceId());
 		attributes.put("parentCalendarBookingId", getParentCalendarBookingId());
+		attributes.put("recurringCalendarBookingId",
+			getRecurringCalendarBookingId());
 		attributes.put("vEventUid", getVEventUid());
 		attributes.put("title", getTitle());
 		attributes.put("description", getDescription());
@@ -166,6 +168,13 @@ public class CalendarBookingWrapper implements CalendarBooking,
 
 		if (parentCalendarBookingId != null) {
 			setParentCalendarBookingId(parentCalendarBookingId);
+		}
+
+		Long recurringCalendarBookingId = (Long)attributes.get(
+				"recurringCalendarBookingId");
+
+		if (recurringCalendarBookingId != null) {
+			setRecurringCalendarBookingId(recurringCalendarBookingId);
 		}
 
 		String vEventUid = (String)attributes.get("vEventUid");
@@ -581,6 +590,16 @@ public class CalendarBookingWrapper implements CalendarBooking,
 	@Override
 	public com.liferay.calendar.recurrence.Recurrence getRecurrenceObj() {
 		return _calendarBooking.getRecurrenceObj();
+	}
+
+	/**
+	* Returns the recurring calendar booking ID of this calendar booking.
+	*
+	* @return the recurring calendar booking ID of this calendar booking
+	*/
+	@Override
+	public long getRecurringCalendarBookingId() {
+		return _calendarBooking.getRecurringCalendarBookingId();
 	}
 
 	/**
@@ -1267,6 +1286,16 @@ public class CalendarBookingWrapper implements CalendarBooking,
 	@Override
 	public void setRecurrence(java.lang.String recurrence) {
 		_calendarBooking.setRecurrence(recurrence);
+	}
+
+	/**
+	* Sets the recurring calendar booking ID of this calendar booking.
+	*
+	* @param recurringCalendarBookingId the recurring calendar booking ID of this calendar booking
+	*/
+	@Override
+	public void setRecurringCalendarBookingId(long recurringCalendarBookingId) {
+		_calendarBooking.setRecurringCalendarBookingId(recurringCalendarBookingId);
 	}
 
 	/**

--- a/modules/apps/forms-and-workflow/calendar/calendar-api/src/main/java/com/liferay/calendar/service/persistence/CalendarBookingPersistence.java
+++ b/modules/apps/forms-and-workflow/calendar/calendar-api/src/main/java/com/liferay/calendar/service/persistence/CalendarBookingPersistence.java
@@ -911,6 +911,145 @@ public interface CalendarBookingPersistence extends BasePersistence<CalendarBook
 	public int countByParentCalendarBookingId(long parentCalendarBookingId);
 
 	/**
+	* Returns all the calendar bookings where recurringCalendarBookingId = &#63;.
+	*
+	* @param recurringCalendarBookingId the recurring calendar booking ID
+	* @return the matching calendar bookings
+	*/
+	public java.util.List<CalendarBooking> findByRecurringCalendarBookingId(
+		long recurringCalendarBookingId);
+
+	/**
+	* Returns a range of all the calendar bookings where recurringCalendarBookingId = &#63;.
+	*
+	* <p>
+	* Useful when paginating results. Returns a maximum of <code>end - start</code> instances. <code>start</code> and <code>end</code> are not primary keys, they are indexes in the result set. Thus, <code>0</code> refers to the first result in the set. Setting both <code>start</code> and <code>end</code> to {@link QueryUtil#ALL_POS} will return the full result set. If <code>orderByComparator</code> is specified, then the query will include the given ORDER BY logic. If <code>orderByComparator</code> is absent and pagination is required (<code>start</code> and <code>end</code> are not {@link QueryUtil#ALL_POS}), then the query will include the default ORDER BY logic from {@link CalendarBookingModelImpl}. If both <code>orderByComparator</code> and pagination are absent, for performance reasons, the query will not have an ORDER BY clause and the returned result set will be sorted on by the primary key in an ascending order.
+	* </p>
+	*
+	* @param recurringCalendarBookingId the recurring calendar booking ID
+	* @param start the lower bound of the range of calendar bookings
+	* @param end the upper bound of the range of calendar bookings (not inclusive)
+	* @return the range of matching calendar bookings
+	*/
+	public java.util.List<CalendarBooking> findByRecurringCalendarBookingId(
+		long recurringCalendarBookingId, int start, int end);
+
+	/**
+	* Returns an ordered range of all the calendar bookings where recurringCalendarBookingId = &#63;.
+	*
+	* <p>
+	* Useful when paginating results. Returns a maximum of <code>end - start</code> instances. <code>start</code> and <code>end</code> are not primary keys, they are indexes in the result set. Thus, <code>0</code> refers to the first result in the set. Setting both <code>start</code> and <code>end</code> to {@link QueryUtil#ALL_POS} will return the full result set. If <code>orderByComparator</code> is specified, then the query will include the given ORDER BY logic. If <code>orderByComparator</code> is absent and pagination is required (<code>start</code> and <code>end</code> are not {@link QueryUtil#ALL_POS}), then the query will include the default ORDER BY logic from {@link CalendarBookingModelImpl}. If both <code>orderByComparator</code> and pagination are absent, for performance reasons, the query will not have an ORDER BY clause and the returned result set will be sorted on by the primary key in an ascending order.
+	* </p>
+	*
+	* @param recurringCalendarBookingId the recurring calendar booking ID
+	* @param start the lower bound of the range of calendar bookings
+	* @param end the upper bound of the range of calendar bookings (not inclusive)
+	* @param orderByComparator the comparator to order the results by (optionally <code>null</code>)
+	* @return the ordered range of matching calendar bookings
+	*/
+	public java.util.List<CalendarBooking> findByRecurringCalendarBookingId(
+		long recurringCalendarBookingId, int start, int end,
+		com.liferay.portal.kernel.util.OrderByComparator<CalendarBooking> orderByComparator);
+
+	/**
+	* Returns an ordered range of all the calendar bookings where recurringCalendarBookingId = &#63;.
+	*
+	* <p>
+	* Useful when paginating results. Returns a maximum of <code>end - start</code> instances. <code>start</code> and <code>end</code> are not primary keys, they are indexes in the result set. Thus, <code>0</code> refers to the first result in the set. Setting both <code>start</code> and <code>end</code> to {@link QueryUtil#ALL_POS} will return the full result set. If <code>orderByComparator</code> is specified, then the query will include the given ORDER BY logic. If <code>orderByComparator</code> is absent and pagination is required (<code>start</code> and <code>end</code> are not {@link QueryUtil#ALL_POS}), then the query will include the default ORDER BY logic from {@link CalendarBookingModelImpl}. If both <code>orderByComparator</code> and pagination are absent, for performance reasons, the query will not have an ORDER BY clause and the returned result set will be sorted on by the primary key in an ascending order.
+	* </p>
+	*
+	* @param recurringCalendarBookingId the recurring calendar booking ID
+	* @param start the lower bound of the range of calendar bookings
+	* @param end the upper bound of the range of calendar bookings (not inclusive)
+	* @param orderByComparator the comparator to order the results by (optionally <code>null</code>)
+	* @param retrieveFromCache whether to retrieve from the finder cache
+	* @return the ordered range of matching calendar bookings
+	*/
+	public java.util.List<CalendarBooking> findByRecurringCalendarBookingId(
+		long recurringCalendarBookingId, int start, int end,
+		com.liferay.portal.kernel.util.OrderByComparator<CalendarBooking> orderByComparator,
+		boolean retrieveFromCache);
+
+	/**
+	* Returns the first calendar booking in the ordered set where recurringCalendarBookingId = &#63;.
+	*
+	* @param recurringCalendarBookingId the recurring calendar booking ID
+	* @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
+	* @return the first matching calendar booking
+	* @throws NoSuchBookingException if a matching calendar booking could not be found
+	*/
+	public CalendarBooking findByRecurringCalendarBookingId_First(
+		long recurringCalendarBookingId,
+		com.liferay.portal.kernel.util.OrderByComparator<CalendarBooking> orderByComparator)
+		throws NoSuchBookingException;
+
+	/**
+	* Returns the first calendar booking in the ordered set where recurringCalendarBookingId = &#63;.
+	*
+	* @param recurringCalendarBookingId the recurring calendar booking ID
+	* @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
+	* @return the first matching calendar booking, or <code>null</code> if a matching calendar booking could not be found
+	*/
+	public CalendarBooking fetchByRecurringCalendarBookingId_First(
+		long recurringCalendarBookingId,
+		com.liferay.portal.kernel.util.OrderByComparator<CalendarBooking> orderByComparator);
+
+	/**
+	* Returns the last calendar booking in the ordered set where recurringCalendarBookingId = &#63;.
+	*
+	* @param recurringCalendarBookingId the recurring calendar booking ID
+	* @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
+	* @return the last matching calendar booking
+	* @throws NoSuchBookingException if a matching calendar booking could not be found
+	*/
+	public CalendarBooking findByRecurringCalendarBookingId_Last(
+		long recurringCalendarBookingId,
+		com.liferay.portal.kernel.util.OrderByComparator<CalendarBooking> orderByComparator)
+		throws NoSuchBookingException;
+
+	/**
+	* Returns the last calendar booking in the ordered set where recurringCalendarBookingId = &#63;.
+	*
+	* @param recurringCalendarBookingId the recurring calendar booking ID
+	* @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
+	* @return the last matching calendar booking, or <code>null</code> if a matching calendar booking could not be found
+	*/
+	public CalendarBooking fetchByRecurringCalendarBookingId_Last(
+		long recurringCalendarBookingId,
+		com.liferay.portal.kernel.util.OrderByComparator<CalendarBooking> orderByComparator);
+
+	/**
+	* Returns the calendar bookings before and after the current calendar booking in the ordered set where recurringCalendarBookingId = &#63;.
+	*
+	* @param calendarBookingId the primary key of the current calendar booking
+	* @param recurringCalendarBookingId the recurring calendar booking ID
+	* @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
+	* @return the previous, current, and next calendar booking
+	* @throws NoSuchBookingException if a calendar booking with the primary key could not be found
+	*/
+	public CalendarBooking[] findByRecurringCalendarBookingId_PrevAndNext(
+		long calendarBookingId, long recurringCalendarBookingId,
+		com.liferay.portal.kernel.util.OrderByComparator<CalendarBooking> orderByComparator)
+		throws NoSuchBookingException;
+
+	/**
+	* Removes all the calendar bookings where recurringCalendarBookingId = &#63; from the database.
+	*
+	* @param recurringCalendarBookingId the recurring calendar booking ID
+	*/
+	public void removeByRecurringCalendarBookingId(
+		long recurringCalendarBookingId);
+
+	/**
+	* Returns the number of calendar bookings where recurringCalendarBookingId = &#63;.
+	*
+	* @param recurringCalendarBookingId the recurring calendar booking ID
+	* @return the number of matching calendar bookings
+	*/
+	public int countByRecurringCalendarBookingId(
+		long recurringCalendarBookingId);
+
+	/**
 	* Returns the calendar booking where calendarId = &#63; and parentCalendarBookingId = &#63; or throws a {@link NoSuchBookingException} if it could not be found.
 	*
 	* @param calendarId the calendar ID

--- a/modules/apps/forms-and-workflow/calendar/calendar-api/src/main/java/com/liferay/calendar/service/persistence/CalendarBookingUtil.java
+++ b/modules/apps/forms-and-workflow/calendar/calendar-api/src/main/java/com/liferay/calendar/service/persistence/CalendarBookingUtil.java
@@ -1196,6 +1196,186 @@ public class CalendarBookingUtil {
 	}
 
 	/**
+	* Returns all the calendar bookings where recurringCalendarBookingId = &#63;.
+	*
+	* @param recurringCalendarBookingId the recurring calendar booking ID
+	* @return the matching calendar bookings
+	*/
+	public static List<CalendarBooking> findByRecurringCalendarBookingId(
+		long recurringCalendarBookingId) {
+		return getPersistence()
+				   .findByRecurringCalendarBookingId(recurringCalendarBookingId);
+	}
+
+	/**
+	* Returns a range of all the calendar bookings where recurringCalendarBookingId = &#63;.
+	*
+	* <p>
+	* Useful when paginating results. Returns a maximum of <code>end - start</code> instances. <code>start</code> and <code>end</code> are not primary keys, they are indexes in the result set. Thus, <code>0</code> refers to the first result in the set. Setting both <code>start</code> and <code>end</code> to {@link QueryUtil#ALL_POS} will return the full result set. If <code>orderByComparator</code> is specified, then the query will include the given ORDER BY logic. If <code>orderByComparator</code> is absent and pagination is required (<code>start</code> and <code>end</code> are not {@link QueryUtil#ALL_POS}), then the query will include the default ORDER BY logic from {@link CalendarBookingModelImpl}. If both <code>orderByComparator</code> and pagination are absent, for performance reasons, the query will not have an ORDER BY clause and the returned result set will be sorted on by the primary key in an ascending order.
+	* </p>
+	*
+	* @param recurringCalendarBookingId the recurring calendar booking ID
+	* @param start the lower bound of the range of calendar bookings
+	* @param end the upper bound of the range of calendar bookings (not inclusive)
+	* @return the range of matching calendar bookings
+	*/
+	public static List<CalendarBooking> findByRecurringCalendarBookingId(
+		long recurringCalendarBookingId, int start, int end) {
+		return getPersistence()
+				   .findByRecurringCalendarBookingId(recurringCalendarBookingId,
+			start, end);
+	}
+
+	/**
+	* Returns an ordered range of all the calendar bookings where recurringCalendarBookingId = &#63;.
+	*
+	* <p>
+	* Useful when paginating results. Returns a maximum of <code>end - start</code> instances. <code>start</code> and <code>end</code> are not primary keys, they are indexes in the result set. Thus, <code>0</code> refers to the first result in the set. Setting both <code>start</code> and <code>end</code> to {@link QueryUtil#ALL_POS} will return the full result set. If <code>orderByComparator</code> is specified, then the query will include the given ORDER BY logic. If <code>orderByComparator</code> is absent and pagination is required (<code>start</code> and <code>end</code> are not {@link QueryUtil#ALL_POS}), then the query will include the default ORDER BY logic from {@link CalendarBookingModelImpl}. If both <code>orderByComparator</code> and pagination are absent, for performance reasons, the query will not have an ORDER BY clause and the returned result set will be sorted on by the primary key in an ascending order.
+	* </p>
+	*
+	* @param recurringCalendarBookingId the recurring calendar booking ID
+	* @param start the lower bound of the range of calendar bookings
+	* @param end the upper bound of the range of calendar bookings (not inclusive)
+	* @param orderByComparator the comparator to order the results by (optionally <code>null</code>)
+	* @return the ordered range of matching calendar bookings
+	*/
+	public static List<CalendarBooking> findByRecurringCalendarBookingId(
+		long recurringCalendarBookingId, int start, int end,
+		OrderByComparator<CalendarBooking> orderByComparator) {
+		return getPersistence()
+				   .findByRecurringCalendarBookingId(recurringCalendarBookingId,
+			start, end, orderByComparator);
+	}
+
+	/**
+	* Returns an ordered range of all the calendar bookings where recurringCalendarBookingId = &#63;.
+	*
+	* <p>
+	* Useful when paginating results. Returns a maximum of <code>end - start</code> instances. <code>start</code> and <code>end</code> are not primary keys, they are indexes in the result set. Thus, <code>0</code> refers to the first result in the set. Setting both <code>start</code> and <code>end</code> to {@link QueryUtil#ALL_POS} will return the full result set. If <code>orderByComparator</code> is specified, then the query will include the given ORDER BY logic. If <code>orderByComparator</code> is absent and pagination is required (<code>start</code> and <code>end</code> are not {@link QueryUtil#ALL_POS}), then the query will include the default ORDER BY logic from {@link CalendarBookingModelImpl}. If both <code>orderByComparator</code> and pagination are absent, for performance reasons, the query will not have an ORDER BY clause and the returned result set will be sorted on by the primary key in an ascending order.
+	* </p>
+	*
+	* @param recurringCalendarBookingId the recurring calendar booking ID
+	* @param start the lower bound of the range of calendar bookings
+	* @param end the upper bound of the range of calendar bookings (not inclusive)
+	* @param orderByComparator the comparator to order the results by (optionally <code>null</code>)
+	* @param retrieveFromCache whether to retrieve from the finder cache
+	* @return the ordered range of matching calendar bookings
+	*/
+	public static List<CalendarBooking> findByRecurringCalendarBookingId(
+		long recurringCalendarBookingId, int start, int end,
+		OrderByComparator<CalendarBooking> orderByComparator,
+		boolean retrieveFromCache) {
+		return getPersistence()
+				   .findByRecurringCalendarBookingId(recurringCalendarBookingId,
+			start, end, orderByComparator, retrieveFromCache);
+	}
+
+	/**
+	* Returns the first calendar booking in the ordered set where recurringCalendarBookingId = &#63;.
+	*
+	* @param recurringCalendarBookingId the recurring calendar booking ID
+	* @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
+	* @return the first matching calendar booking
+	* @throws NoSuchBookingException if a matching calendar booking could not be found
+	*/
+	public static CalendarBooking findByRecurringCalendarBookingId_First(
+		long recurringCalendarBookingId,
+		OrderByComparator<CalendarBooking> orderByComparator)
+		throws com.liferay.calendar.exception.NoSuchBookingException {
+		return getPersistence()
+				   .findByRecurringCalendarBookingId_First(recurringCalendarBookingId,
+			orderByComparator);
+	}
+
+	/**
+	* Returns the first calendar booking in the ordered set where recurringCalendarBookingId = &#63;.
+	*
+	* @param recurringCalendarBookingId the recurring calendar booking ID
+	* @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
+	* @return the first matching calendar booking, or <code>null</code> if a matching calendar booking could not be found
+	*/
+	public static CalendarBooking fetchByRecurringCalendarBookingId_First(
+		long recurringCalendarBookingId,
+		OrderByComparator<CalendarBooking> orderByComparator) {
+		return getPersistence()
+				   .fetchByRecurringCalendarBookingId_First(recurringCalendarBookingId,
+			orderByComparator);
+	}
+
+	/**
+	* Returns the last calendar booking in the ordered set where recurringCalendarBookingId = &#63;.
+	*
+	* @param recurringCalendarBookingId the recurring calendar booking ID
+	* @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
+	* @return the last matching calendar booking
+	* @throws NoSuchBookingException if a matching calendar booking could not be found
+	*/
+	public static CalendarBooking findByRecurringCalendarBookingId_Last(
+		long recurringCalendarBookingId,
+		OrderByComparator<CalendarBooking> orderByComparator)
+		throws com.liferay.calendar.exception.NoSuchBookingException {
+		return getPersistence()
+				   .findByRecurringCalendarBookingId_Last(recurringCalendarBookingId,
+			orderByComparator);
+	}
+
+	/**
+	* Returns the last calendar booking in the ordered set where recurringCalendarBookingId = &#63;.
+	*
+	* @param recurringCalendarBookingId the recurring calendar booking ID
+	* @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
+	* @return the last matching calendar booking, or <code>null</code> if a matching calendar booking could not be found
+	*/
+	public static CalendarBooking fetchByRecurringCalendarBookingId_Last(
+		long recurringCalendarBookingId,
+		OrderByComparator<CalendarBooking> orderByComparator) {
+		return getPersistence()
+				   .fetchByRecurringCalendarBookingId_Last(recurringCalendarBookingId,
+			orderByComparator);
+	}
+
+	/**
+	* Returns the calendar bookings before and after the current calendar booking in the ordered set where recurringCalendarBookingId = &#63;.
+	*
+	* @param calendarBookingId the primary key of the current calendar booking
+	* @param recurringCalendarBookingId the recurring calendar booking ID
+	* @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
+	* @return the previous, current, and next calendar booking
+	* @throws NoSuchBookingException if a calendar booking with the primary key could not be found
+	*/
+	public static CalendarBooking[] findByRecurringCalendarBookingId_PrevAndNext(
+		long calendarBookingId, long recurringCalendarBookingId,
+		OrderByComparator<CalendarBooking> orderByComparator)
+		throws com.liferay.calendar.exception.NoSuchBookingException {
+		return getPersistence()
+				   .findByRecurringCalendarBookingId_PrevAndNext(calendarBookingId,
+			recurringCalendarBookingId, orderByComparator);
+	}
+
+	/**
+	* Removes all the calendar bookings where recurringCalendarBookingId = &#63; from the database.
+	*
+	* @param recurringCalendarBookingId the recurring calendar booking ID
+	*/
+	public static void removeByRecurringCalendarBookingId(
+		long recurringCalendarBookingId) {
+		getPersistence()
+			.removeByRecurringCalendarBookingId(recurringCalendarBookingId);
+	}
+
+	/**
+	* Returns the number of calendar bookings where recurringCalendarBookingId = &#63;.
+	*
+	* @param recurringCalendarBookingId the recurring calendar booking ID
+	* @return the number of matching calendar bookings
+	*/
+	public static int countByRecurringCalendarBookingId(
+		long recurringCalendarBookingId) {
+		return getPersistence()
+				   .countByRecurringCalendarBookingId(recurringCalendarBookingId);
+	}
+
+	/**
 	* Returns the calendar booking where calendarId = &#63; and parentCalendarBookingId = &#63; or throws a {@link NoSuchBookingException} if it could not be found.
 	*
 	* @param calendarId the calendar ID

--- a/modules/apps/forms-and-workflow/calendar/calendar-service/service.xml
+++ b/modules/apps/forms-and-workflow/calendar/calendar-service/service.xml
@@ -87,6 +87,7 @@
 		<column name="calendarId" type="long" />
 		<column name="calendarResourceId" type="long" />
 		<column name="parentCalendarBookingId" type="long" />
+		<column name="recurringCalendarBookingId" type="long" />
 		<column name="vEventUid" type="String" />
 		<column name="title" type="String" localized="true" />
 		<column name="description" type="String" localized="true" />
@@ -122,6 +123,9 @@
 		</finder>
 		<finder name="ParentCalendarBookingId" return-type="Collection">
 			<finder-column name="parentCalendarBookingId" />
+		</finder>
+		<finder name="RecurringCalendarBookingId" return-type="Collection">
+			<finder-column name="recurringCalendarBookingId" />
 		</finder>
 		<finder name="C_P" return-type="CalendarBooking" unique="true">
 			<finder-column name="calendarId" />

--- a/modules/apps/forms-and-workflow/calendar/calendar-service/src/main/java/com/liferay/calendar/model/impl/CalendarBookingCacheModel.java
+++ b/modules/apps/forms-and-workflow/calendar/calendar-service/src/main/java/com/liferay/calendar/model/impl/CalendarBookingCacheModel.java
@@ -66,7 +66,7 @@ public class CalendarBookingCacheModel implements CacheModel<CalendarBooking>,
 
 	@Override
 	public String toString() {
-		StringBundler sb = new StringBundler(59);
+		StringBundler sb = new StringBundler(61);
 
 		sb.append("{uuid=");
 		sb.append(uuid);
@@ -92,6 +92,8 @@ public class CalendarBookingCacheModel implements CacheModel<CalendarBooking>,
 		sb.append(calendarResourceId);
 		sb.append(", parentCalendarBookingId=");
 		sb.append(parentCalendarBookingId);
+		sb.append(", recurringCalendarBookingId=");
+		sb.append(recurringCalendarBookingId);
 		sb.append(", vEventUid=");
 		sb.append(vEventUid);
 		sb.append(", title=");
@@ -172,6 +174,7 @@ public class CalendarBookingCacheModel implements CacheModel<CalendarBooking>,
 		calendarBookingImpl.setCalendarId(calendarId);
 		calendarBookingImpl.setCalendarResourceId(calendarResourceId);
 		calendarBookingImpl.setParentCalendarBookingId(parentCalendarBookingId);
+		calendarBookingImpl.setRecurringCalendarBookingId(recurringCalendarBookingId);
 
 		if (vEventUid == null) {
 			calendarBookingImpl.setVEventUid(StringPool.BLANK);
@@ -281,6 +284,8 @@ public class CalendarBookingCacheModel implements CacheModel<CalendarBooking>,
 		calendarResourceId = objectInput.readLong();
 
 		parentCalendarBookingId = objectInput.readLong();
+
+		recurringCalendarBookingId = objectInput.readLong();
 		vEventUid = objectInput.readUTF();
 		title = objectInput.readUTF();
 		description = objectInput.readUTF();
@@ -342,6 +347,8 @@ public class CalendarBookingCacheModel implements CacheModel<CalendarBooking>,
 		objectOutput.writeLong(calendarResourceId);
 
 		objectOutput.writeLong(parentCalendarBookingId);
+
+		objectOutput.writeLong(recurringCalendarBookingId);
 
 		if (vEventUid == null) {
 			objectOutput.writeUTF(StringPool.BLANK);
@@ -430,6 +437,7 @@ public class CalendarBookingCacheModel implements CacheModel<CalendarBooking>,
 	public long calendarId;
 	public long calendarResourceId;
 	public long parentCalendarBookingId;
+	public long recurringCalendarBookingId;
 	public String vEventUid;
 	public String title;
 	public String description;

--- a/modules/apps/forms-and-workflow/calendar/calendar-service/src/main/java/com/liferay/calendar/model/impl/CalendarBookingModelImpl.java
+++ b/modules/apps/forms-and-workflow/calendar/calendar-service/src/main/java/com/liferay/calendar/model/impl/CalendarBookingModelImpl.java
@@ -101,6 +101,7 @@ public class CalendarBookingModelImpl extends BaseModelImpl<CalendarBooking>
 			{ "calendarId", Types.BIGINT },
 			{ "calendarResourceId", Types.BIGINT },
 			{ "parentCalendarBookingId", Types.BIGINT },
+			{ "recurringCalendarBookingId", Types.BIGINT },
 			{ "vEventUid", Types.VARCHAR },
 			{ "title", Types.VARCHAR },
 			{ "description", Types.CLOB },
@@ -134,6 +135,7 @@ public class CalendarBookingModelImpl extends BaseModelImpl<CalendarBooking>
 		TABLE_COLUMNS_MAP.put("calendarId", Types.BIGINT);
 		TABLE_COLUMNS_MAP.put("calendarResourceId", Types.BIGINT);
 		TABLE_COLUMNS_MAP.put("parentCalendarBookingId", Types.BIGINT);
+		TABLE_COLUMNS_MAP.put("recurringCalendarBookingId", Types.BIGINT);
 		TABLE_COLUMNS_MAP.put("vEventUid", Types.VARCHAR);
 		TABLE_COLUMNS_MAP.put("title", Types.VARCHAR);
 		TABLE_COLUMNS_MAP.put("description", Types.CLOB);
@@ -153,7 +155,7 @@ public class CalendarBookingModelImpl extends BaseModelImpl<CalendarBooking>
 		TABLE_COLUMNS_MAP.put("statusDate", Types.TIMESTAMP);
 	}
 
-	public static final String TABLE_SQL_CREATE = "create table CalendarBooking (uuid_ VARCHAR(75) null,calendarBookingId LONG not null primary key,groupId LONG,companyId LONG,userId LONG,userName VARCHAR(75) null,createDate DATE null,modifiedDate DATE null,resourceBlockId LONG,calendarId LONG,calendarResourceId LONG,parentCalendarBookingId LONG,vEventUid VARCHAR(255) null,title STRING null,description TEXT null,location STRING null,startTime LONG,endTime LONG,allDay BOOLEAN,recurrence STRING null,firstReminder LONG,firstReminderType VARCHAR(75) null,secondReminder LONG,secondReminderType VARCHAR(75) null,lastPublishDate DATE null,status INTEGER,statusByUserId LONG,statusByUserName VARCHAR(75) null,statusDate DATE null)";
+	public static final String TABLE_SQL_CREATE = "create table CalendarBooking (uuid_ VARCHAR(75) null,calendarBookingId LONG not null primary key,groupId LONG,companyId LONG,userId LONG,userName VARCHAR(75) null,createDate DATE null,modifiedDate DATE null,resourceBlockId LONG,calendarId LONG,calendarResourceId LONG,parentCalendarBookingId LONG,recurringCalendarBookingId LONG,vEventUid VARCHAR(255) null,title STRING null,description TEXT null,location STRING null,startTime LONG,endTime LONG,allDay BOOLEAN,recurrence STRING null,firstReminder LONG,firstReminderType VARCHAR(75) null,secondReminder LONG,secondReminderType VARCHAR(75) null,lastPublishDate DATE null,status INTEGER,statusByUserId LONG,statusByUserName VARCHAR(75) null,statusDate DATE null)";
 	public static final String TABLE_SQL_DROP = "drop table CalendarBooking";
 	public static final String ORDER_BY_JPQL = " ORDER BY calendarBooking.startTime ASC, calendarBooking.title ASC";
 	public static final String ORDER_BY_SQL = " ORDER BY CalendarBooking.startTime ASC, CalendarBooking.title ASC";
@@ -174,12 +176,13 @@ public class CalendarBookingModelImpl extends BaseModelImpl<CalendarBooking>
 	public static final long COMPANYID_COLUMN_BITMASK = 4L;
 	public static final long GROUPID_COLUMN_BITMASK = 8L;
 	public static final long PARENTCALENDARBOOKINGID_COLUMN_BITMASK = 16L;
-	public static final long RESOURCEBLOCKID_COLUMN_BITMASK = 32L;
-	public static final long STATUS_COLUMN_BITMASK = 64L;
-	public static final long UUID_COLUMN_BITMASK = 128L;
-	public static final long VEVENTUID_COLUMN_BITMASK = 256L;
-	public static final long STARTTIME_COLUMN_BITMASK = 512L;
-	public static final long TITLE_COLUMN_BITMASK = 1024L;
+	public static final long RECURRINGCALENDARBOOKINGID_COLUMN_BITMASK = 32L;
+	public static final long RESOURCEBLOCKID_COLUMN_BITMASK = 64L;
+	public static final long STATUS_COLUMN_BITMASK = 128L;
+	public static final long UUID_COLUMN_BITMASK = 256L;
+	public static final long VEVENTUID_COLUMN_BITMASK = 512L;
+	public static final long STARTTIME_COLUMN_BITMASK = 1024L;
+	public static final long TITLE_COLUMN_BITMASK = 2048L;
 
 	/**
 	 * Converts the soap model instance into a normal model instance.
@@ -206,6 +209,7 @@ public class CalendarBookingModelImpl extends BaseModelImpl<CalendarBooking>
 		model.setCalendarId(soapModel.getCalendarId());
 		model.setCalendarResourceId(soapModel.getCalendarResourceId());
 		model.setParentCalendarBookingId(soapModel.getParentCalendarBookingId());
+		model.setRecurringCalendarBookingId(soapModel.getRecurringCalendarBookingId());
 		model.setVEventUid(soapModel.getVEventUid());
 		model.setTitle(soapModel.getTitle());
 		model.setDescription(soapModel.getDescription());
@@ -300,6 +304,8 @@ public class CalendarBookingModelImpl extends BaseModelImpl<CalendarBooking>
 		attributes.put("calendarId", getCalendarId());
 		attributes.put("calendarResourceId", getCalendarResourceId());
 		attributes.put("parentCalendarBookingId", getParentCalendarBookingId());
+		attributes.put("recurringCalendarBookingId",
+			getRecurringCalendarBookingId());
 		attributes.put("vEventUid", getVEventUid());
 		attributes.put("title", getTitle());
 		attributes.put("description", getDescription());
@@ -397,6 +403,13 @@ public class CalendarBookingModelImpl extends BaseModelImpl<CalendarBooking>
 
 		if (parentCalendarBookingId != null) {
 			setParentCalendarBookingId(parentCalendarBookingId);
+		}
+
+		Long recurringCalendarBookingId = (Long)attributes.get(
+				"recurringCalendarBookingId");
+
+		if (recurringCalendarBookingId != null) {
+			setRecurringCalendarBookingId(recurringCalendarBookingId);
 		}
 
 		String vEventUid = (String)attributes.get("vEventUid");
@@ -744,6 +757,29 @@ public class CalendarBookingModelImpl extends BaseModelImpl<CalendarBooking>
 
 	public long getOriginalParentCalendarBookingId() {
 		return _originalParentCalendarBookingId;
+	}
+
+	@JSON
+	@Override
+	public long getRecurringCalendarBookingId() {
+		return _recurringCalendarBookingId;
+	}
+
+	@Override
+	public void setRecurringCalendarBookingId(long recurringCalendarBookingId) {
+		_columnBitmask |= RECURRINGCALENDARBOOKINGID_COLUMN_BITMASK;
+
+		if (!_setOriginalRecurringCalendarBookingId) {
+			_setOriginalRecurringCalendarBookingId = true;
+
+			_originalRecurringCalendarBookingId = _recurringCalendarBookingId;
+		}
+
+		_recurringCalendarBookingId = recurringCalendarBookingId;
+	}
+
+	public long getOriginalRecurringCalendarBookingId() {
+		return _originalRecurringCalendarBookingId;
 	}
 
 	@JSON
@@ -1527,6 +1563,7 @@ public class CalendarBookingModelImpl extends BaseModelImpl<CalendarBooking>
 		calendarBookingImpl.setCalendarId(getCalendarId());
 		calendarBookingImpl.setCalendarResourceId(getCalendarResourceId());
 		calendarBookingImpl.setParentCalendarBookingId(getParentCalendarBookingId());
+		calendarBookingImpl.setRecurringCalendarBookingId(getRecurringCalendarBookingId());
 		calendarBookingImpl.setVEventUid(getVEventUid());
 		calendarBookingImpl.setTitle(getTitle());
 		calendarBookingImpl.setDescription(getDescription());
@@ -1646,6 +1683,10 @@ public class CalendarBookingModelImpl extends BaseModelImpl<CalendarBooking>
 
 		calendarBookingModelImpl._setOriginalParentCalendarBookingId = false;
 
+		calendarBookingModelImpl._originalRecurringCalendarBookingId = calendarBookingModelImpl._recurringCalendarBookingId;
+
+		calendarBookingModelImpl._setOriginalRecurringCalendarBookingId = false;
+
 		calendarBookingModelImpl._originalVEventUid = calendarBookingModelImpl._vEventUid;
 
 		calendarBookingModelImpl._originalStatus = calendarBookingModelImpl._status;
@@ -1708,6 +1749,8 @@ public class CalendarBookingModelImpl extends BaseModelImpl<CalendarBooking>
 		calendarBookingCacheModel.calendarResourceId = getCalendarResourceId();
 
 		calendarBookingCacheModel.parentCalendarBookingId = getParentCalendarBookingId();
+
+		calendarBookingCacheModel.recurringCalendarBookingId = getRecurringCalendarBookingId();
 
 		calendarBookingCacheModel.vEventUid = getVEventUid();
 
@@ -1810,7 +1853,7 @@ public class CalendarBookingModelImpl extends BaseModelImpl<CalendarBooking>
 
 	@Override
 	public String toString() {
-		StringBundler sb = new StringBundler(59);
+		StringBundler sb = new StringBundler(61);
 
 		sb.append("{uuid=");
 		sb.append(getUuid());
@@ -1836,6 +1879,8 @@ public class CalendarBookingModelImpl extends BaseModelImpl<CalendarBooking>
 		sb.append(getCalendarResourceId());
 		sb.append(", parentCalendarBookingId=");
 		sb.append(getParentCalendarBookingId());
+		sb.append(", recurringCalendarBookingId=");
+		sb.append(getRecurringCalendarBookingId());
 		sb.append(", vEventUid=");
 		sb.append(getVEventUid());
 		sb.append(", title=");
@@ -1877,7 +1922,7 @@ public class CalendarBookingModelImpl extends BaseModelImpl<CalendarBooking>
 
 	@Override
 	public String toXmlString() {
-		StringBundler sb = new StringBundler(91);
+		StringBundler sb = new StringBundler(94);
 
 		sb.append("<model><model-name>");
 		sb.append("com.liferay.calendar.model.CalendarBooking");
@@ -1930,6 +1975,10 @@ public class CalendarBookingModelImpl extends BaseModelImpl<CalendarBooking>
 		sb.append(
 			"<column><column-name>parentCalendarBookingId</column-name><column-value><![CDATA[");
 		sb.append(getParentCalendarBookingId());
+		sb.append("]]></column-value></column>");
+		sb.append(
+			"<column><column-name>recurringCalendarBookingId</column-name><column-value><![CDATA[");
+		sb.append(getRecurringCalendarBookingId());
 		sb.append("]]></column-value></column>");
 		sb.append(
 			"<column><column-name>vEventUid</column-name><column-value><![CDATA[");
@@ -2035,6 +2084,9 @@ public class CalendarBookingModelImpl extends BaseModelImpl<CalendarBooking>
 	private long _parentCalendarBookingId;
 	private long _originalParentCalendarBookingId;
 	private boolean _setOriginalParentCalendarBookingId;
+	private long _recurringCalendarBookingId;
+	private long _originalRecurringCalendarBookingId;
+	private boolean _setOriginalRecurringCalendarBookingId;
 	private String _vEventUid;
 	private String _originalVEventUid;
 	private String _title;

--- a/modules/apps/forms-and-workflow/calendar/calendar-service/src/main/java/com/liferay/calendar/service/persistence/impl/CalendarBookingPersistenceImpl.java
+++ b/modules/apps/forms-and-workflow/calendar/calendar-service/src/main/java/com/liferay/calendar/service/persistence/impl/CalendarBookingPersistenceImpl.java
@@ -3576,6 +3576,540 @@ public class CalendarBookingPersistenceImpl extends BasePersistenceImpl<Calendar
 
 	private static final String _FINDER_COLUMN_PARENTCALENDARBOOKINGID_PARENTCALENDARBOOKINGID_2 =
 		"calendarBooking.parentCalendarBookingId = ?";
+	public static final FinderPath FINDER_PATH_WITH_PAGINATION_FIND_BY_RECURRINGCALENDARBOOKINGID =
+		new FinderPath(CalendarBookingModelImpl.ENTITY_CACHE_ENABLED,
+			CalendarBookingModelImpl.FINDER_CACHE_ENABLED,
+			CalendarBookingImpl.class, FINDER_CLASS_NAME_LIST_WITH_PAGINATION,
+			"findByRecurringCalendarBookingId",
+			new String[] {
+				Long.class.getName(),
+				
+			Integer.class.getName(), Integer.class.getName(),
+				OrderByComparator.class.getName()
+			});
+	public static final FinderPath FINDER_PATH_WITHOUT_PAGINATION_FIND_BY_RECURRINGCALENDARBOOKINGID =
+		new FinderPath(CalendarBookingModelImpl.ENTITY_CACHE_ENABLED,
+			CalendarBookingModelImpl.FINDER_CACHE_ENABLED,
+			CalendarBookingImpl.class,
+			FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION,
+			"findByRecurringCalendarBookingId",
+			new String[] { Long.class.getName() },
+			CalendarBookingModelImpl.RECURRINGCALENDARBOOKINGID_COLUMN_BITMASK |
+			CalendarBookingModelImpl.STARTTIME_COLUMN_BITMASK |
+			CalendarBookingModelImpl.TITLE_COLUMN_BITMASK);
+	public static final FinderPath FINDER_PATH_COUNT_BY_RECURRINGCALENDARBOOKINGID =
+		new FinderPath(CalendarBookingModelImpl.ENTITY_CACHE_ENABLED,
+			CalendarBookingModelImpl.FINDER_CACHE_ENABLED, Long.class,
+			FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION,
+			"countByRecurringCalendarBookingId",
+			new String[] { Long.class.getName() });
+
+	/**
+	 * Returns all the calendar bookings where recurringCalendarBookingId = &#63;.
+	 *
+	 * @param recurringCalendarBookingId the recurring calendar booking ID
+	 * @return the matching calendar bookings
+	 */
+	@Override
+	public List<CalendarBooking> findByRecurringCalendarBookingId(
+		long recurringCalendarBookingId) {
+		return findByRecurringCalendarBookingId(recurringCalendarBookingId,
+			QueryUtil.ALL_POS, QueryUtil.ALL_POS, null);
+	}
+
+	/**
+	 * Returns a range of all the calendar bookings where recurringCalendarBookingId = &#63;.
+	 *
+	 * <p>
+	 * Useful when paginating results. Returns a maximum of <code>end - start</code> instances. <code>start</code> and <code>end</code> are not primary keys, they are indexes in the result set. Thus, <code>0</code> refers to the first result in the set. Setting both <code>start</code> and <code>end</code> to {@link QueryUtil#ALL_POS} will return the full result set. If <code>orderByComparator</code> is specified, then the query will include the given ORDER BY logic. If <code>orderByComparator</code> is absent and pagination is required (<code>start</code> and <code>end</code> are not {@link QueryUtil#ALL_POS}), then the query will include the default ORDER BY logic from {@link CalendarBookingModelImpl}. If both <code>orderByComparator</code> and pagination are absent, for performance reasons, the query will not have an ORDER BY clause and the returned result set will be sorted on by the primary key in an ascending order.
+	 * </p>
+	 *
+	 * @param recurringCalendarBookingId the recurring calendar booking ID
+	 * @param start the lower bound of the range of calendar bookings
+	 * @param end the upper bound of the range of calendar bookings (not inclusive)
+	 * @return the range of matching calendar bookings
+	 */
+	@Override
+	public List<CalendarBooking> findByRecurringCalendarBookingId(
+		long recurringCalendarBookingId, int start, int end) {
+		return findByRecurringCalendarBookingId(recurringCalendarBookingId,
+			start, end, null);
+	}
+
+	/**
+	 * Returns an ordered range of all the calendar bookings where recurringCalendarBookingId = &#63;.
+	 *
+	 * <p>
+	 * Useful when paginating results. Returns a maximum of <code>end - start</code> instances. <code>start</code> and <code>end</code> are not primary keys, they are indexes in the result set. Thus, <code>0</code> refers to the first result in the set. Setting both <code>start</code> and <code>end</code> to {@link QueryUtil#ALL_POS} will return the full result set. If <code>orderByComparator</code> is specified, then the query will include the given ORDER BY logic. If <code>orderByComparator</code> is absent and pagination is required (<code>start</code> and <code>end</code> are not {@link QueryUtil#ALL_POS}), then the query will include the default ORDER BY logic from {@link CalendarBookingModelImpl}. If both <code>orderByComparator</code> and pagination are absent, for performance reasons, the query will not have an ORDER BY clause and the returned result set will be sorted on by the primary key in an ascending order.
+	 * </p>
+	 *
+	 * @param recurringCalendarBookingId the recurring calendar booking ID
+	 * @param start the lower bound of the range of calendar bookings
+	 * @param end the upper bound of the range of calendar bookings (not inclusive)
+	 * @param orderByComparator the comparator to order the results by (optionally <code>null</code>)
+	 * @return the ordered range of matching calendar bookings
+	 */
+	@Override
+	public List<CalendarBooking> findByRecurringCalendarBookingId(
+		long recurringCalendarBookingId, int start, int end,
+		OrderByComparator<CalendarBooking> orderByComparator) {
+		return findByRecurringCalendarBookingId(recurringCalendarBookingId,
+			start, end, orderByComparator, true);
+	}
+
+	/**
+	 * Returns an ordered range of all the calendar bookings where recurringCalendarBookingId = &#63;.
+	 *
+	 * <p>
+	 * Useful when paginating results. Returns a maximum of <code>end - start</code> instances. <code>start</code> and <code>end</code> are not primary keys, they are indexes in the result set. Thus, <code>0</code> refers to the first result in the set. Setting both <code>start</code> and <code>end</code> to {@link QueryUtil#ALL_POS} will return the full result set. If <code>orderByComparator</code> is specified, then the query will include the given ORDER BY logic. If <code>orderByComparator</code> is absent and pagination is required (<code>start</code> and <code>end</code> are not {@link QueryUtil#ALL_POS}), then the query will include the default ORDER BY logic from {@link CalendarBookingModelImpl}. If both <code>orderByComparator</code> and pagination are absent, for performance reasons, the query will not have an ORDER BY clause and the returned result set will be sorted on by the primary key in an ascending order.
+	 * </p>
+	 *
+	 * @param recurringCalendarBookingId the recurring calendar booking ID
+	 * @param start the lower bound of the range of calendar bookings
+	 * @param end the upper bound of the range of calendar bookings (not inclusive)
+	 * @param orderByComparator the comparator to order the results by (optionally <code>null</code>)
+	 * @param retrieveFromCache whether to retrieve from the finder cache
+	 * @return the ordered range of matching calendar bookings
+	 */
+	@Override
+	public List<CalendarBooking> findByRecurringCalendarBookingId(
+		long recurringCalendarBookingId, int start, int end,
+		OrderByComparator<CalendarBooking> orderByComparator,
+		boolean retrieveFromCache) {
+		boolean pagination = true;
+		FinderPath finderPath = null;
+		Object[] finderArgs = null;
+
+		if ((start == QueryUtil.ALL_POS) && (end == QueryUtil.ALL_POS) &&
+				(orderByComparator == null)) {
+			pagination = false;
+			finderPath = FINDER_PATH_WITHOUT_PAGINATION_FIND_BY_RECURRINGCALENDARBOOKINGID;
+			finderArgs = new Object[] { recurringCalendarBookingId };
+		}
+		else {
+			finderPath = FINDER_PATH_WITH_PAGINATION_FIND_BY_RECURRINGCALENDARBOOKINGID;
+			finderArgs = new Object[] {
+					recurringCalendarBookingId,
+					
+					start, end, orderByComparator
+				};
+		}
+
+		List<CalendarBooking> list = null;
+
+		if (retrieveFromCache) {
+			list = (List<CalendarBooking>)finderCache.getResult(finderPath,
+					finderArgs, this);
+
+			if ((list != null) && !list.isEmpty()) {
+				for (CalendarBooking calendarBooking : list) {
+					if ((recurringCalendarBookingId != calendarBooking.getRecurringCalendarBookingId())) {
+						list = null;
+
+						break;
+					}
+				}
+			}
+		}
+
+		if (list == null) {
+			StringBundler query = null;
+
+			if (orderByComparator != null) {
+				query = new StringBundler(3 +
+						(orderByComparator.getOrderByFields().length * 2));
+			}
+			else {
+				query = new StringBundler(3);
+			}
+
+			query.append(_SQL_SELECT_CALENDARBOOKING_WHERE);
+
+			query.append(_FINDER_COLUMN_RECURRINGCALENDARBOOKINGID_RECURRINGCALENDARBOOKINGID_2);
+
+			if (orderByComparator != null) {
+				appendOrderByComparator(query, _ORDER_BY_ENTITY_ALIAS,
+					orderByComparator);
+			}
+			else
+			 if (pagination) {
+				query.append(CalendarBookingModelImpl.ORDER_BY_JPQL);
+			}
+
+			String sql = query.toString();
+
+			Session session = null;
+
+			try {
+				session = openSession();
+
+				Query q = session.createQuery(sql);
+
+				QueryPos qPos = QueryPos.getInstance(q);
+
+				qPos.add(recurringCalendarBookingId);
+
+				if (!pagination) {
+					list = (List<CalendarBooking>)QueryUtil.list(q,
+							getDialect(), start, end, false);
+
+					Collections.sort(list);
+
+					list = Collections.unmodifiableList(list);
+				}
+				else {
+					list = (List<CalendarBooking>)QueryUtil.list(q,
+							getDialect(), start, end);
+				}
+
+				cacheResult(list);
+
+				finderCache.putResult(finderPath, finderArgs, list);
+			}
+			catch (Exception e) {
+				finderCache.removeResult(finderPath, finderArgs);
+
+				throw processException(e);
+			}
+			finally {
+				closeSession(session);
+			}
+		}
+
+		return list;
+	}
+
+	/**
+	 * Returns the first calendar booking in the ordered set where recurringCalendarBookingId = &#63;.
+	 *
+	 * @param recurringCalendarBookingId the recurring calendar booking ID
+	 * @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
+	 * @return the first matching calendar booking
+	 * @throws NoSuchBookingException if a matching calendar booking could not be found
+	 */
+	@Override
+	public CalendarBooking findByRecurringCalendarBookingId_First(
+		long recurringCalendarBookingId,
+		OrderByComparator<CalendarBooking> orderByComparator)
+		throws NoSuchBookingException {
+		CalendarBooking calendarBooking = fetchByRecurringCalendarBookingId_First(recurringCalendarBookingId,
+				orderByComparator);
+
+		if (calendarBooking != null) {
+			return calendarBooking;
+		}
+
+		StringBundler msg = new StringBundler(4);
+
+		msg.append(_NO_SUCH_ENTITY_WITH_KEY);
+
+		msg.append("recurringCalendarBookingId=");
+		msg.append(recurringCalendarBookingId);
+
+		msg.append(StringPool.CLOSE_CURLY_BRACE);
+
+		throw new NoSuchBookingException(msg.toString());
+	}
+
+	/**
+	 * Returns the first calendar booking in the ordered set where recurringCalendarBookingId = &#63;.
+	 *
+	 * @param recurringCalendarBookingId the recurring calendar booking ID
+	 * @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
+	 * @return the first matching calendar booking, or <code>null</code> if a matching calendar booking could not be found
+	 */
+	@Override
+	public CalendarBooking fetchByRecurringCalendarBookingId_First(
+		long recurringCalendarBookingId,
+		OrderByComparator<CalendarBooking> orderByComparator) {
+		List<CalendarBooking> list = findByRecurringCalendarBookingId(recurringCalendarBookingId,
+				0, 1, orderByComparator);
+
+		if (!list.isEmpty()) {
+			return list.get(0);
+		}
+
+		return null;
+	}
+
+	/**
+	 * Returns the last calendar booking in the ordered set where recurringCalendarBookingId = &#63;.
+	 *
+	 * @param recurringCalendarBookingId the recurring calendar booking ID
+	 * @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
+	 * @return the last matching calendar booking
+	 * @throws NoSuchBookingException if a matching calendar booking could not be found
+	 */
+	@Override
+	public CalendarBooking findByRecurringCalendarBookingId_Last(
+		long recurringCalendarBookingId,
+		OrderByComparator<CalendarBooking> orderByComparator)
+		throws NoSuchBookingException {
+		CalendarBooking calendarBooking = fetchByRecurringCalendarBookingId_Last(recurringCalendarBookingId,
+				orderByComparator);
+
+		if (calendarBooking != null) {
+			return calendarBooking;
+		}
+
+		StringBundler msg = new StringBundler(4);
+
+		msg.append(_NO_SUCH_ENTITY_WITH_KEY);
+
+		msg.append("recurringCalendarBookingId=");
+		msg.append(recurringCalendarBookingId);
+
+		msg.append(StringPool.CLOSE_CURLY_BRACE);
+
+		throw new NoSuchBookingException(msg.toString());
+	}
+
+	/**
+	 * Returns the last calendar booking in the ordered set where recurringCalendarBookingId = &#63;.
+	 *
+	 * @param recurringCalendarBookingId the recurring calendar booking ID
+	 * @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
+	 * @return the last matching calendar booking, or <code>null</code> if a matching calendar booking could not be found
+	 */
+	@Override
+	public CalendarBooking fetchByRecurringCalendarBookingId_Last(
+		long recurringCalendarBookingId,
+		OrderByComparator<CalendarBooking> orderByComparator) {
+		int count = countByRecurringCalendarBookingId(recurringCalendarBookingId);
+
+		if (count == 0) {
+			return null;
+		}
+
+		List<CalendarBooking> list = findByRecurringCalendarBookingId(recurringCalendarBookingId,
+				count - 1, count, orderByComparator);
+
+		if (!list.isEmpty()) {
+			return list.get(0);
+		}
+
+		return null;
+	}
+
+	/**
+	 * Returns the calendar bookings before and after the current calendar booking in the ordered set where recurringCalendarBookingId = &#63;.
+	 *
+	 * @param calendarBookingId the primary key of the current calendar booking
+	 * @param recurringCalendarBookingId the recurring calendar booking ID
+	 * @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
+	 * @return the previous, current, and next calendar booking
+	 * @throws NoSuchBookingException if a calendar booking with the primary key could not be found
+	 */
+	@Override
+	public CalendarBooking[] findByRecurringCalendarBookingId_PrevAndNext(
+		long calendarBookingId, long recurringCalendarBookingId,
+		OrderByComparator<CalendarBooking> orderByComparator)
+		throws NoSuchBookingException {
+		CalendarBooking calendarBooking = findByPrimaryKey(calendarBookingId);
+
+		Session session = null;
+
+		try {
+			session = openSession();
+
+			CalendarBooking[] array = new CalendarBookingImpl[3];
+
+			array[0] = getByRecurringCalendarBookingId_PrevAndNext(session,
+					calendarBooking, recurringCalendarBookingId,
+					orderByComparator, true);
+
+			array[1] = calendarBooking;
+
+			array[2] = getByRecurringCalendarBookingId_PrevAndNext(session,
+					calendarBooking, recurringCalendarBookingId,
+					orderByComparator, false);
+
+			return array;
+		}
+		catch (Exception e) {
+			throw processException(e);
+		}
+		finally {
+			closeSession(session);
+		}
+	}
+
+	protected CalendarBooking getByRecurringCalendarBookingId_PrevAndNext(
+		Session session, CalendarBooking calendarBooking,
+		long recurringCalendarBookingId,
+		OrderByComparator<CalendarBooking> orderByComparator, boolean previous) {
+		StringBundler query = null;
+
+		if (orderByComparator != null) {
+			query = new StringBundler(4 +
+					(orderByComparator.getOrderByConditionFields().length * 3) +
+					(orderByComparator.getOrderByFields().length * 3));
+		}
+		else {
+			query = new StringBundler(3);
+		}
+
+		query.append(_SQL_SELECT_CALENDARBOOKING_WHERE);
+
+		query.append(_FINDER_COLUMN_RECURRINGCALENDARBOOKINGID_RECURRINGCALENDARBOOKINGID_2);
+
+		if (orderByComparator != null) {
+			String[] orderByConditionFields = orderByComparator.getOrderByConditionFields();
+
+			if (orderByConditionFields.length > 0) {
+				query.append(WHERE_AND);
+			}
+
+			for (int i = 0; i < orderByConditionFields.length; i++) {
+				query.append(_ORDER_BY_ENTITY_ALIAS);
+				query.append(orderByConditionFields[i]);
+
+				if ((i + 1) < orderByConditionFields.length) {
+					if (orderByComparator.isAscending() ^ previous) {
+						query.append(WHERE_GREATER_THAN_HAS_NEXT);
+					}
+					else {
+						query.append(WHERE_LESSER_THAN_HAS_NEXT);
+					}
+				}
+				else {
+					if (orderByComparator.isAscending() ^ previous) {
+						query.append(WHERE_GREATER_THAN);
+					}
+					else {
+						query.append(WHERE_LESSER_THAN);
+					}
+				}
+			}
+
+			query.append(ORDER_BY_CLAUSE);
+
+			String[] orderByFields = orderByComparator.getOrderByFields();
+
+			for (int i = 0; i < orderByFields.length; i++) {
+				query.append(_ORDER_BY_ENTITY_ALIAS);
+				query.append(orderByFields[i]);
+
+				if ((i + 1) < orderByFields.length) {
+					if (orderByComparator.isAscending() ^ previous) {
+						query.append(ORDER_BY_ASC_HAS_NEXT);
+					}
+					else {
+						query.append(ORDER_BY_DESC_HAS_NEXT);
+					}
+				}
+				else {
+					if (orderByComparator.isAscending() ^ previous) {
+						query.append(ORDER_BY_ASC);
+					}
+					else {
+						query.append(ORDER_BY_DESC);
+					}
+				}
+			}
+		}
+		else {
+			query.append(CalendarBookingModelImpl.ORDER_BY_JPQL);
+		}
+
+		String sql = query.toString();
+
+		Query q = session.createQuery(sql);
+
+		q.setFirstResult(0);
+		q.setMaxResults(2);
+
+		QueryPos qPos = QueryPos.getInstance(q);
+
+		qPos.add(recurringCalendarBookingId);
+
+		if (orderByComparator != null) {
+			Object[] values = orderByComparator.getOrderByConditionValues(calendarBooking);
+
+			for (Object value : values) {
+				qPos.add(value);
+			}
+		}
+
+		List<CalendarBooking> list = q.list();
+
+		if (list.size() == 2) {
+			return list.get(1);
+		}
+		else {
+			return null;
+		}
+	}
+
+	/**
+	 * Removes all the calendar bookings where recurringCalendarBookingId = &#63; from the database.
+	 *
+	 * @param recurringCalendarBookingId the recurring calendar booking ID
+	 */
+	@Override
+	public void removeByRecurringCalendarBookingId(
+		long recurringCalendarBookingId) {
+		for (CalendarBooking calendarBooking : findByRecurringCalendarBookingId(
+				recurringCalendarBookingId, QueryUtil.ALL_POS,
+				QueryUtil.ALL_POS, null)) {
+			remove(calendarBooking);
+		}
+	}
+
+	/**
+	 * Returns the number of calendar bookings where recurringCalendarBookingId = &#63;.
+	 *
+	 * @param recurringCalendarBookingId the recurring calendar booking ID
+	 * @return the number of matching calendar bookings
+	 */
+	@Override
+	public int countByRecurringCalendarBookingId(
+		long recurringCalendarBookingId) {
+		FinderPath finderPath = FINDER_PATH_COUNT_BY_RECURRINGCALENDARBOOKINGID;
+
+		Object[] finderArgs = new Object[] { recurringCalendarBookingId };
+
+		Long count = (Long)finderCache.getResult(finderPath, finderArgs, this);
+
+		if (count == null) {
+			StringBundler query = new StringBundler(2);
+
+			query.append(_SQL_COUNT_CALENDARBOOKING_WHERE);
+
+			query.append(_FINDER_COLUMN_RECURRINGCALENDARBOOKINGID_RECURRINGCALENDARBOOKINGID_2);
+
+			String sql = query.toString();
+
+			Session session = null;
+
+			try {
+				session = openSession();
+
+				Query q = session.createQuery(sql);
+
+				QueryPos qPos = QueryPos.getInstance(q);
+
+				qPos.add(recurringCalendarBookingId);
+
+				count = (Long)q.uniqueResult();
+
+				finderCache.putResult(finderPath, finderArgs, count);
+			}
+			catch (Exception e) {
+				finderCache.removeResult(finderPath, finderArgs);
+
+				throw processException(e);
+			}
+			finally {
+				closeSession(session);
+			}
+		}
+
+		return count.intValue();
+	}
+
+	private static final String _FINDER_COLUMN_RECURRINGCALENDARBOOKINGID_RECURRINGCALENDARBOOKINGID_2 =
+		"calendarBooking.recurringCalendarBookingId = ?";
 	public static final FinderPath FINDER_PATH_FETCH_BY_C_P = new FinderPath(CalendarBookingModelImpl.ENTITY_CACHE_ENABLED,
 			CalendarBookingModelImpl.FINDER_CACHE_ENABLED,
 			CalendarBookingImpl.class, FINDER_CLASS_NAME_ENTITY, "fetchByC_P",
@@ -5966,6 +6500,27 @@ public class CalendarBookingPersistenceImpl extends BasePersistenceImpl<Calendar
 			}
 
 			if ((calendarBookingModelImpl.getColumnBitmask() &
+					FINDER_PATH_WITHOUT_PAGINATION_FIND_BY_RECURRINGCALENDARBOOKINGID.getColumnBitmask()) != 0) {
+				Object[] args = new Object[] {
+						calendarBookingModelImpl.getOriginalRecurringCalendarBookingId()
+					};
+
+				finderCache.removeResult(FINDER_PATH_COUNT_BY_RECURRINGCALENDARBOOKINGID,
+					args);
+				finderCache.removeResult(FINDER_PATH_WITHOUT_PAGINATION_FIND_BY_RECURRINGCALENDARBOOKINGID,
+					args);
+
+				args = new Object[] {
+						calendarBookingModelImpl.getRecurringCalendarBookingId()
+					};
+
+				finderCache.removeResult(FINDER_PATH_COUNT_BY_RECURRINGCALENDARBOOKINGID,
+					args);
+				finderCache.removeResult(FINDER_PATH_WITHOUT_PAGINATION_FIND_BY_RECURRINGCALENDARBOOKINGID,
+					args);
+			}
+
+			if ((calendarBookingModelImpl.getColumnBitmask() &
 					FINDER_PATH_WITHOUT_PAGINATION_FIND_BY_C_S.getColumnBitmask()) != 0) {
 				Object[] args = new Object[] {
 						calendarBookingModelImpl.getOriginalCalendarId(),
@@ -6042,6 +6597,7 @@ public class CalendarBookingPersistenceImpl extends BasePersistenceImpl<Calendar
 		calendarBookingImpl.setCalendarId(calendarBooking.getCalendarId());
 		calendarBookingImpl.setCalendarResourceId(calendarBooking.getCalendarResourceId());
 		calendarBookingImpl.setParentCalendarBookingId(calendarBooking.getParentCalendarBookingId());
+		calendarBookingImpl.setRecurringCalendarBookingId(calendarBooking.getRecurringCalendarBookingId());
 		calendarBookingImpl.setVEventUid(calendarBooking.getVEventUid());
 		calendarBookingImpl.setTitle(calendarBooking.getTitle());
 		calendarBookingImpl.setDescription(calendarBooking.getDescription());

--- a/modules/apps/forms-and-workflow/calendar/calendar-service/src/main/java/com/liferay/calendar/service/persistence/impl/CalendarBookingPersistenceImpl.java
+++ b/modules/apps/forms-and-workflow/calendar/calendar-service/src/main/java/com/liferay/calendar/service/persistence/impl/CalendarBookingPersistenceImpl.java
@@ -1200,8 +1200,8 @@ public class CalendarBookingPersistenceImpl extends BasePersistenceImpl<Calendar
 
 			msg.append(StringPool.CLOSE_CURLY_BRACE);
 
-			if (_log.isDebugEnabled()) {
-				_log.debug(msg.toString());
+			if (_log.isWarnEnabled()) {
+				_log.warn(msg.toString());
 			}
 
 			throw new NoSuchBookingException(msg.toString());
@@ -3614,8 +3614,8 @@ public class CalendarBookingPersistenceImpl extends BasePersistenceImpl<Calendar
 
 			msg.append(StringPool.CLOSE_CURLY_BRACE);
 
-			if (_log.isDebugEnabled()) {
-				_log.debug(msg.toString());
+			if (_log.isWarnEnabled()) {
+				_log.warn(msg.toString());
 			}
 
 			throw new NoSuchBookingException(msg.toString());
@@ -3839,8 +3839,8 @@ public class CalendarBookingPersistenceImpl extends BasePersistenceImpl<Calendar
 
 			msg.append(StringPool.CLOSE_CURLY_BRACE);
 
-			if (_log.isDebugEnabled()) {
-				_log.debug(msg.toString());
+			if (_log.isWarnEnabled()) {
+				_log.warn(msg.toString());
 			}
 
 			throw new NoSuchBookingException(msg.toString());
@@ -5729,8 +5729,8 @@ public class CalendarBookingPersistenceImpl extends BasePersistenceImpl<Calendar
 					primaryKey);
 
 			if (calendarBooking == null) {
-				if (_log.isDebugEnabled()) {
-					_log.debug(_NO_SUCH_ENTITY_WITH_PRIMARY_KEY + primaryKey);
+				if (_log.isWarnEnabled()) {
+					_log.warn(_NO_SUCH_ENTITY_WITH_PRIMARY_KEY + primaryKey);
 				}
 
 				throw new NoSuchBookingException(_NO_SUCH_ENTITY_WITH_PRIMARY_KEY +
@@ -6076,8 +6076,8 @@ public class CalendarBookingPersistenceImpl extends BasePersistenceImpl<Calendar
 		CalendarBooking calendarBooking = fetchByPrimaryKey(primaryKey);
 
 		if (calendarBooking == null) {
-			if (_log.isDebugEnabled()) {
-				_log.debug(_NO_SUCH_ENTITY_WITH_PRIMARY_KEY + primaryKey);
+			if (_log.isWarnEnabled()) {
+				_log.warn(_NO_SUCH_ENTITY_WITH_PRIMARY_KEY + primaryKey);
 			}
 
 			throw new NoSuchBookingException(_NO_SUCH_ENTITY_WITH_PRIMARY_KEY +

--- a/modules/apps/forms-and-workflow/calendar/calendar-service/src/main/java/com/liferay/calendar/service/persistence/impl/CalendarNotificationTemplatePersistenceImpl.java
+++ b/modules/apps/forms-and-workflow/calendar/calendar-service/src/main/java/com/liferay/calendar/service/persistence/impl/CalendarNotificationTemplatePersistenceImpl.java
@@ -690,8 +690,8 @@ public class CalendarNotificationTemplatePersistenceImpl
 
 			msg.append(StringPool.CLOSE_CURLY_BRACE);
 
-			if (_log.isDebugEnabled()) {
-				_log.debug(msg.toString());
+			if (_log.isWarnEnabled()) {
+				_log.warn(msg.toString());
 			}
 
 			throw new NoSuchNotificationTemplateException(msg.toString());
@@ -2081,8 +2081,8 @@ public class CalendarNotificationTemplatePersistenceImpl
 
 			msg.append(StringPool.CLOSE_CURLY_BRACE);
 
-			if (_log.isDebugEnabled()) {
-				_log.debug(msg.toString());
+			if (_log.isWarnEnabled()) {
+				_log.warn(msg.toString());
 			}
 
 			throw new NoSuchNotificationTemplateException(msg.toString());
@@ -2629,8 +2629,8 @@ public class CalendarNotificationTemplatePersistenceImpl
 					primaryKey);
 
 			if (calendarNotificationTemplate == null) {
-				if (_log.isDebugEnabled()) {
-					_log.debug(_NO_SUCH_ENTITY_WITH_PRIMARY_KEY + primaryKey);
+				if (_log.isWarnEnabled()) {
+					_log.warn(_NO_SUCH_ENTITY_WITH_PRIMARY_KEY + primaryKey);
 				}
 
 				throw new NoSuchNotificationTemplateException(_NO_SUCH_ENTITY_WITH_PRIMARY_KEY +
@@ -2868,8 +2868,8 @@ public class CalendarNotificationTemplatePersistenceImpl
 		CalendarNotificationTemplate calendarNotificationTemplate = fetchByPrimaryKey(primaryKey);
 
 		if (calendarNotificationTemplate == null) {
-			if (_log.isDebugEnabled()) {
-				_log.debug(_NO_SUCH_ENTITY_WITH_PRIMARY_KEY + primaryKey);
+			if (_log.isWarnEnabled()) {
+				_log.warn(_NO_SUCH_ENTITY_WITH_PRIMARY_KEY + primaryKey);
 			}
 
 			throw new NoSuchNotificationTemplateException(_NO_SUCH_ENTITY_WITH_PRIMARY_KEY +

--- a/modules/apps/forms-and-workflow/calendar/calendar-service/src/main/java/com/liferay/calendar/service/persistence/impl/CalendarPersistenceImpl.java
+++ b/modules/apps/forms-and-workflow/calendar/calendar-service/src/main/java/com/liferay/calendar/service/persistence/impl/CalendarPersistenceImpl.java
@@ -1184,8 +1184,8 @@ public class CalendarPersistenceImpl extends BasePersistenceImpl<Calendar>
 
 			msg.append(StringPool.CLOSE_CURLY_BRACE);
 
-			if (_log.isDebugEnabled()) {
-				_log.debug(msg.toString());
+			if (_log.isWarnEnabled()) {
+				_log.warn(msg.toString());
 			}
 
 			throw new NoSuchCalendarException(msg.toString());
@@ -3967,8 +3967,8 @@ public class CalendarPersistenceImpl extends BasePersistenceImpl<Calendar>
 					primaryKey);
 
 			if (calendar == null) {
-				if (_log.isDebugEnabled()) {
-					_log.debug(_NO_SUCH_ENTITY_WITH_PRIMARY_KEY + primaryKey);
+				if (_log.isWarnEnabled()) {
+					_log.warn(_NO_SUCH_ENTITY_WITH_PRIMARY_KEY + primaryKey);
 				}
 
 				throw new NoSuchCalendarException(_NO_SUCH_ENTITY_WITH_PRIMARY_KEY +
@@ -4240,8 +4240,8 @@ public class CalendarPersistenceImpl extends BasePersistenceImpl<Calendar>
 		Calendar calendar = fetchByPrimaryKey(primaryKey);
 
 		if (calendar == null) {
-			if (_log.isDebugEnabled()) {
-				_log.debug(_NO_SUCH_ENTITY_WITH_PRIMARY_KEY + primaryKey);
+			if (_log.isWarnEnabled()) {
+				_log.warn(_NO_SUCH_ENTITY_WITH_PRIMARY_KEY + primaryKey);
 			}
 
 			throw new NoSuchCalendarException(_NO_SUCH_ENTITY_WITH_PRIMARY_KEY +

--- a/modules/apps/forms-and-workflow/calendar/calendar-service/src/main/java/com/liferay/calendar/service/persistence/impl/CalendarResourcePersistenceImpl.java
+++ b/modules/apps/forms-and-workflow/calendar/calendar-service/src/main/java/com/liferay/calendar/service/persistence/impl/CalendarResourcePersistenceImpl.java
@@ -1202,8 +1202,8 @@ public class CalendarResourcePersistenceImpl extends BasePersistenceImpl<Calenda
 
 			msg.append(StringPool.CLOSE_CURLY_BRACE);
 
-			if (_log.isDebugEnabled()) {
-				_log.debug(msg.toString());
+			if (_log.isWarnEnabled()) {
+				_log.warn(msg.toString());
 			}
 
 			throw new NoSuchResourceException(msg.toString());
@@ -5712,8 +5712,8 @@ public class CalendarResourcePersistenceImpl extends BasePersistenceImpl<Calenda
 
 			msg.append(StringPool.CLOSE_CURLY_BRACE);
 
-			if (_log.isDebugEnabled()) {
-				_log.debug(msg.toString());
+			if (_log.isWarnEnabled()) {
+				_log.warn(msg.toString());
 			}
 
 			throw new NoSuchResourceException(msg.toString());
@@ -6756,8 +6756,8 @@ public class CalendarResourcePersistenceImpl extends BasePersistenceImpl<Calenda
 					primaryKey);
 
 			if (calendarResource == null) {
-				if (_log.isDebugEnabled()) {
-					_log.debug(_NO_SUCH_ENTITY_WITH_PRIMARY_KEY + primaryKey);
+				if (_log.isWarnEnabled()) {
+					_log.warn(_NO_SUCH_ENTITY_WITH_PRIMARY_KEY + primaryKey);
 				}
 
 				throw new NoSuchResourceException(_NO_SUCH_ENTITY_WITH_PRIMARY_KEY +
@@ -7067,8 +7067,8 @@ public class CalendarResourcePersistenceImpl extends BasePersistenceImpl<Calenda
 		CalendarResource calendarResource = fetchByPrimaryKey(primaryKey);
 
 		if (calendarResource == null) {
-			if (_log.isDebugEnabled()) {
-				_log.debug(_NO_SUCH_ENTITY_WITH_PRIMARY_KEY + primaryKey);
+			if (_log.isWarnEnabled()) {
+				_log.warn(_NO_SUCH_ENTITY_WITH_PRIMARY_KEY + primaryKey);
 			}
 
 			throw new NoSuchResourceException(_NO_SUCH_ENTITY_WITH_PRIMARY_KEY +

--- a/modules/apps/forms-and-workflow/calendar/calendar-service/src/main/resources/META-INF/module-hbm.xml
+++ b/modules/apps/forms-and-workflow/calendar/calendar-service/src/main/resources/META-INF/module-hbm.xml
@@ -43,6 +43,7 @@
 		<property name="calendarId" type="com.liferay.portal.dao.orm.hibernate.LongType" />
 		<property name="calendarResourceId" type="com.liferay.portal.dao.orm.hibernate.LongType" />
 		<property name="parentCalendarBookingId" type="com.liferay.portal.dao.orm.hibernate.LongType" />
+		<property name="recurringCalendarBookingId" type="com.liferay.portal.dao.orm.hibernate.LongType" />
 		<property name="vEventUid" access="com.liferay.portal.dao.orm.hibernate.CamelCasePropertyAccessor" type="com.liferay.portal.dao.orm.hibernate.StringType" />
 		<property name="title" type="com.liferay.portal.dao.orm.hibernate.StringType" />
 		<property name="description" type="com.liferay.portal.dao.orm.hibernate.StringClobType" />

--- a/modules/apps/forms-and-workflow/calendar/calendar-service/src/main/resources/META-INF/portlet-model-hints.xml
+++ b/modules/apps/forms-and-workflow/calendar/calendar-service/src/main/resources/META-INF/portlet-model-hints.xml
@@ -36,6 +36,7 @@
 		<field name="calendarId" type="long" />
 		<field name="calendarResourceId" type="long" />
 		<field name="parentCalendarBookingId" type="long" />
+		<field name="recurringCalendarBookingId" type="long" />
 		<field name="vEventUid" type="String">
 			<hint name="max-length">255</hint>
 		</field>

--- a/modules/apps/forms-and-workflow/calendar/calendar-service/src/main/resources/META-INF/sql/indexes.sql
+++ b/modules/apps/forms-and-workflow/calendar/calendar-service/src/main/resources/META-INF/sql/indexes.sql
@@ -8,6 +8,7 @@ create index IX_470170B4 on CalendarBooking (calendarId, status);
 create unique index IX_8B23DA0E on CalendarBooking (calendarId, vEventUid[$COLUMN_LENGTH:255$]);
 create index IX_B198FFC on CalendarBooking (calendarResourceId);
 create index IX_F7B8A941 on CalendarBooking (parentCalendarBookingId, status);
+create index IX_14ADC52E on CalendarBooking (recurringCalendarBookingId);
 create index IX_22DFDB49 on CalendarBooking (resourceBlockId);
 create index IX_A21D9FD5 on CalendarBooking (uuid_[$COLUMN_LENGTH:75$], companyId);
 create unique index IX_F4C61797 on CalendarBooking (uuid_[$COLUMN_LENGTH:75$], groupId);

--- a/modules/apps/forms-and-workflow/calendar/calendar-service/src/main/resources/META-INF/sql/tables.sql
+++ b/modules/apps/forms-and-workflow/calendar/calendar-service/src/main/resources/META-INF/sql/tables.sql
@@ -32,6 +32,7 @@ create table CalendarBooking (
 	calendarId LONG,
 	calendarResourceId LONG,
 	parentCalendarBookingId LONG,
+	recurringCalendarBookingId LONG,
 	vEventUid VARCHAR(255) null,
 	title STRING null,
 	description TEXT null,

--- a/modules/apps/forms-and-workflow/calendar/calendar-test/src/testIntegration/java/com/liferay/calendar/service/persistence/test/CalendarBookingPersistenceTest.java
+++ b/modules/apps/forms-and-workflow/calendar/calendar-test/src/testIntegration/java/com/liferay/calendar/service/persistence/test/CalendarBookingPersistenceTest.java
@@ -146,6 +146,8 @@ public class CalendarBookingPersistenceTest {
 
 		newCalendarBooking.setParentCalendarBookingId(RandomTestUtil.nextLong());
 
+		newCalendarBooking.setRecurringCalendarBookingId(RandomTestUtil.nextLong());
+
 		newCalendarBooking.setVEventUid(RandomTestUtil.randomString());
 
 		newCalendarBooking.setTitle(RandomTestUtil.randomString());
@@ -210,6 +212,8 @@ public class CalendarBookingPersistenceTest {
 			newCalendarBooking.getCalendarResourceId());
 		Assert.assertEquals(existingCalendarBooking.getParentCalendarBookingId(),
 			newCalendarBooking.getParentCalendarBookingId());
+		Assert.assertEquals(existingCalendarBooking.getRecurringCalendarBookingId(),
+			newCalendarBooking.getRecurringCalendarBookingId());
 		Assert.assertEquals(existingCalendarBooking.getVEventUid(),
 			newCalendarBooking.getVEventUid());
 		Assert.assertEquals(existingCalendarBooking.getTitle(),
@@ -304,6 +308,14 @@ public class CalendarBookingPersistenceTest {
 	}
 
 	@Test
+	public void testCountByRecurringCalendarBookingId()
+		throws Exception {
+		_persistence.countByRecurringCalendarBookingId(RandomTestUtil.nextLong());
+
+		_persistence.countByRecurringCalendarBookingId(0L);
+	}
+
+	@Test
 	public void testCountByC_P() throws Exception {
 		_persistence.countByC_P(RandomTestUtil.nextLong(),
 			RandomTestUtil.nextLong());
@@ -370,11 +382,12 @@ public class CalendarBookingPersistenceTest {
 			true, "userId", true, "userName", true, "createDate", true,
 			"modifiedDate", true, "resourceBlockId", true, "calendarId", true,
 			"calendarResourceId", true, "parentCalendarBookingId", true,
-			"vEventUid", true, "title", true, "location", true, "startTime",
-			true, "endTime", true, "allDay", true, "recurrence", true,
-			"firstReminder", true, "firstReminderType", true, "secondReminder",
-			true, "secondReminderType", true, "lastPublishDate", true,
-			"status", true, "statusByUserId", true, "statusByUserName", true,
+			"recurringCalendarBookingId", true, "vEventUid", true, "title",
+			true, "location", true, "startTime", true, "endTime", true,
+			"allDay", true, "recurrence", true, "firstReminder", true,
+			"firstReminderType", true, "secondReminder", true,
+			"secondReminderType", true, "lastPublishDate", true, "status",
+			true, "statusByUserId", true, "statusByUserName", true,
 			"statusDate", true);
 	}
 
@@ -632,6 +645,8 @@ public class CalendarBookingPersistenceTest {
 		calendarBooking.setCalendarResourceId(RandomTestUtil.nextLong());
 
 		calendarBooking.setParentCalendarBookingId(RandomTestUtil.nextLong());
+
+		calendarBooking.setRecurringCalendarBookingId(RandomTestUtil.nextLong());
 
 		calendarBooking.setVEventUid(RandomTestUtil.randomString());
 


### PR DESCRIPTION
Hey Adam,

Here is the giant pull request for LPS-62735. I added two new columns to the table. One of the new columns is "recurringCalendarBookingId", which is used to link events that are part of the same recurring series, as we discussed. The other new column is "masterRecurrence", which keeps track of the recurrence of the whole series (as opposed to "recurrence", which just keeps track of the recurrence of the individual booking). The masterRecurrence column can be interfaced with and edited by the user, whereas the recurrence column is only ever modified by the software, which updates it appropriately whenever a user modifies instances of an event. The masterRecurrence column is also very helpful for the CalendarBookingIterator to work properly.

The modifications made to the logic for updating instances (commit 0476ee657b6505a07236ba9a52695e6736fecbae) are probably the most confusing. I had to add a bunch of helper methods for them. In the case where the user modifies the recurrence and selects "Only this Instance", nothing happens, since I didn't think it would make sense to modify the recurrence of only one instance. In the case where the user modifies the recurrence and selects "All Following", a separate series of bookings is created since now we have two events with different masterRecurrences.

Here are some known issues I discovered in my testing:

**When you edit a recurring series to have a recurrence in which the first instance doesn't fall within the new recurrence, the first instance will still display.**
Reproducible with the following steps:
1. Create a new daily recurring event that starts on a Sunday.
2. Click on an instance of the recurring event that falls on a Wednesday.
3. Edit the event to recur weekly on every Wednesday.
4. When you hit publish, select "All Events in Series".
**Expected result**: The first instance displayed would be the first Wednesday of the recurrence.
**Actual result**: The first instance displayed is the Sunday the event started on originally.

**The calendar will not accept multiple events on the same day within a recurring series
Reproducible with the following steps:**
1. Create a new daily recurring event.
2. Modify one instance of the event to take place on the following day at a different time.
3. Select "Only this instance".
**Expected result**: The new day would now contain two instances of the event, and the previous day would contain none.
**Actual result**: The new day contains only the modified instance of the event, and the previous day contains an unmodified instance of the event.

**The calendar does not handle recurring events that start and end on a different day very well.
Reproducible with the following steps:**
1. Create a new daily recurring event.
2. Modify one instance of the event to end on the next day.
3. Now modify the event so that it starts on the new day that it ends.
**Expected result**: The calendar booking is successfully updated with the new start and end times.
**Actual result**: A NullPointerException is thrown and the entire series no longer displays.
You can probably see a lot more weird behaviors like this if you experiment with different corner cases. Hopefully not too many people will want to schedule recurring meetings during midnight...