### PR TITLE
[TECHNICAL-SUPPORT] LPS-68451 Agenda view in Calendar does not show the events of the month

### DIFF
--- a/modules/apps/forms-and-workflow/calendar/calendar-web/src/main/resources/META-INF/resources/scheduler.jsp
+++ b/modules/apps/forms-and-workflow/calendar/calendar-web/src/main/resources/META-INF/resources/scheduler.jsp
@@ -98,6 +98,7 @@ String viewCalendarBookingURL = ParamUtil.getString(request, "viewCalendarBookin
 	<c:if test="<%= !hideAgendaView %>">
 		window.<portlet:namespace />agendaView = new Liferay.SchedulerAgendaView(
 			{
+				daysCount: 31,
 				height: 700,
 				isoTime: <%= useIsoTimeFormat %>,
 				readOnly: <%= readOnly %>,

--- a/modules/apps/foundation/configuration-admin/.gitrepo
+++ b/modules/apps/foundation/configuration-admin/.gitrepo
@@ -3,7 +3,7 @@
 ;
 [subrepo]
 	cmdver = liferay
-	commit = 14cdf1c7ba6fd8f41a60466a3c98ec2c2a43d5f7
+	commit = e2bb61c523d7c232cc5b6a8a1a3535050f4bc753
 	mode = push
-	parent = a3f93df4afe225f85cfaed892d2f03d47318c566
+	parent = 6360f473e755b9aa9eb6f561818329737c160026
 	remote = git@github.com:liferay/com-liferay-configuration-admin.git


### PR DESCRIPTION
Hey Adam,

A customer issue was raised about the interval of the agenda view in the calendar portlet.
Agenda view is supposed to show the events in a 1 month interval, as this code proves it as well.

```
if (viewName === 'agenda') {
    date = DateMath.add(date, DateMath.MONTH, 1);
}
```

Since [AUI-2080](https://issues.liferay.com/browse/AUI-2080), the timespan the agenda view is able to display is restricted to a maximum of 30 days by default, but it is possible to set it to a different value.
The attribute which enables this is `daysCount`.

https://github.com/mairatma/alloy-ui/pull/305/files#diff-c8974ba662e46eb5296adfa8ba00c75cR138

In the case two events are 31 days apart, only one of the two events will be shown in the agenda view, because the 30 limit cannot covert both.
Therefore, adding a `daysCount` value of 31 to the construction of SchedulerAgendaView solves this problem.

My question is, is this a proper solution, of maybe we should go in a direction to making this customizable from the UI or with a property?

Thank you!

Best regards,
István
