### PR TITLE
LPS-76325 Adjust classNameId in assetVocabulary settings from calEven…

### DIFF
--- a/modules/apps/forms-and-workflow/calendar/calendar-service/src/main/java/com/liferay/calendar/internal/upgrade/v1_0_4/UpgradeClassNames.java
+++ b/modules/apps/forms-and-workflow/calendar/calendar-service/src/main/java/com/liferay/calendar/internal/upgrade/v1_0_4/UpgradeClassNames.java
@@ -17,10 +17,12 @@ package com.liferay.calendar.internal.upgrade.v1_0_4;
 import com.liferay.portal.kernel.upgrade.UpgradeException;
 import com.liferay.portal.kernel.util.LoggingTimer;
 import com.liferay.portal.kernel.util.StringBundler;
+import com.liferay.portal.kernel.util.StringUtil;
 import com.liferay.portal.upgrade.v7_0_0.UpgradeKernelPackage;
 
 import java.sql.PreparedStatement;
 import java.sql.ResultSet;
+import java.sql.SQLException;
 
 /**
  * @author Cristina González
@@ -29,11 +31,70 @@ public class UpgradeClassNames extends UpgradeKernelPackage {
 
 	@Override
 	public void doUpgrade() throws UpgradeException {
+		changeCalEventClassName();
 		deleteCalEventClassName();
 		deleteDuplicateResourcePermissions();
 		deleteDuplicateResources();
 
 		super.doUpgrade();
+	}
+
+	protected void changeCalEventClassName() throws UpgradeException {
+		try (LoggingTimer loggingTimer = new LoggingTimer();
+			PreparedStatement ps1 = connection.prepareStatement(
+				"select classNameId from ClassName_ where value like ?");
+			PreparedStatement ps2 = connection.prepareStatement(
+				"select vocabularyId, settings_ from AssetVocabulary where " +
+					"settings_ like ?");
+			PreparedStatement ps3 = connection.prepareStatement(
+				"update AssetVocabulary set settings_ = ? where vocabularyId " +
+					"= ?")) {
+
+			String calEventClassNameId = null;
+			String calBookingClassNameId = null;
+
+			ps1.setString(1, _CAL_EVENT_CLASS_NAME + "%");
+			ResultSet rs = ps1.executeQuery();
+
+			if (rs.next()) {
+				calEventClassNameId = rs.getString("classNameId");
+			}
+			else {
+				return;
+			}
+
+			ps1.setString(1, _CALENDAR_BOOKING_CLASS_NAME + "%");
+			rs = ps1.executeQuery();
+
+			if (rs.next()) {
+				calBookingClassNameId = rs.getString("classNameId");
+			}
+			else {
+				return;
+			}
+
+			ps2.setString(1, "%" + calEventClassNameId + "%");
+
+			rs = ps2.executeQuery();
+
+			while (rs.next()) {
+				String oldSettings = rs.getString("settings_");
+				long vocabularyId = rs.getLong("vocabularyId");
+
+				String newSettings = StringUtil.replace(
+					oldSettings, calEventClassNameId, calBookingClassNameId);
+
+				ps3.setString(1, newSettings);
+
+				ps3.setLong(2, vocabularyId);
+
+				ps3.execute();
+			}
+
+		}
+		catch (SQLException sqle) {
+			throw new UpgradeException(sqle);
+		}
 	}
 
 	protected void deleteCalEventClassName() throws UpgradeException {
@@ -135,6 +196,9 @@ public class UpgradeClassNames extends UpgradeKernelPackage {
 
 	private static final String _CAL_EVENT_CLASS_NAME =
 		"com.liferay.portlet.calendar.model.CalEvent";
+
+	private static final String _CALENDAR_BOOKING_CLASS_NAME =
+		"com.liferay.calendar.model.CalendarBooking";
 
 	private static final String[][] _RESOURCE_NAMES = {
 		{"com.liferay.portlet.calendar", "com.liferay.calendar"}


### PR DESCRIPTION
Hello Adam,

When upgrading from 6.1 to 6.2 then to DXP there is an issue with asset vocabularies associated with calendar events. We initially use the CalEvent classNameId to associate the vocabulary, however when we upgrade to DXP, the CalEvent className is removed from the database, but we do not update any associations referencing it. We should be changing the classNameId from CalEvent to CalendarBooking.

Please let me know if there are any questions regarding this fix.

Thanks,
Sam