### PR TITLE
LPS-90067 AssetEntry

### DIFF
--- a/modules/apps/asset/asset-service/build.gradle
+++ b/modules/apps/asset/asset-service/build.gradle
@@ -16,6 +16,8 @@ dependencies {
 	compileOnly project(":apps:asset:asset-category-property-api")
 	compileOnly project(":apps:asset:asset-entry-rel-api")
 	compileOnly project(":apps:dynamic-data-mapping:dynamic-data-mapping-api")
+	compileOnly project(":apps:portal-search:portal-search-api")
+	compileOnly project(":apps:portal-search:portal-search-spi")
 	compileOnly project(":apps:portal-security:portal-security-service-access-policy-api")
 	compileOnly project(":apps:portal:portal-instance-lifecycle-api")
 	compileOnly project(":apps:portal:portal-spring-extender-api")

--- a/modules/apps/asset/asset-service/src/main/java/com/liferay/asset/internal/search/AssetEntryIndexer.java
+++ b/modules/apps/asset/asset-service/src/main/java/com/liferay/asset/internal/search/AssetEntryIndexer.java
@@ -19,7 +19,6 @@ import com.liferay.portal.kernel.search.BaseIndexer;
 import com.liferay.portal.kernel.search.BooleanQuery;
 import com.liferay.portal.kernel.search.Document;
 import com.liferay.portal.kernel.search.Field;
-import com.liferay.portal.kernel.search.Indexer;
 import com.liferay.portal.kernel.search.SearchContext;
 import com.liferay.portal.kernel.search.Summary;
 import com.liferay.portal.kernel.search.filter.BooleanFilter;
@@ -29,13 +28,12 @@ import java.util.Locale;
 import javax.portlet.PortletRequest;
 import javax.portlet.PortletResponse;
 
-import org.osgi.service.component.annotations.Component;
-
 /**
  * @author Brian Wing Shun Chan
  * @author Julio Camarero
+ * @deprecated As of Judson (7.1.x), since 7.1.0
  */
-@Component(immediate = true, service = Indexer.class)
+@Deprecated
 public class AssetEntryIndexer extends BaseIndexer<AssetEntry> {
 
 	public static final String CLASS_NAME = AssetEntry.class.getName();

--- a/modules/apps/asset/asset-service/src/main/java/com/liferay/asset/internal/search/AssetEntrySearchRegistrar.java
+++ b/modules/apps/asset/asset-service/src/main/java/com/liferay/asset/internal/search/AssetEntrySearchRegistrar.java
@@ -1,0 +1,56 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.asset.internal.search;
+
+import com.liferay.asset.kernel.model.AssetEntry;
+import com.liferay.portal.kernel.search.Field;
+import com.liferay.portal.search.spi.model.registrar.ModelSearchRegistrarHelper;
+
+import org.osgi.framework.BundleContext;
+import org.osgi.framework.ServiceRegistration;
+import org.osgi.service.component.annotations.Activate;
+import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.Deactivate;
+import org.osgi.service.component.annotations.Reference;
+
+/**
+ * @author Brian Wing Shun Chan
+ * @author Julio Camarero
+ * @author Vagner B.C
+ */
+@Component(immediate = true, service = {})
+public class AssetEntrySearchRegistrar {
+
+	@Activate
+	protected void activate(BundleContext bundleContext) {
+		_serviceRegistration = modelSearchRegistrarHelper.register(
+			AssetEntry.class, bundleContext,
+			modelSearchDefinition -> {
+				modelSearchDefinition.setDefaultSelectedFieldNames(
+					Field.ENTRY_CLASS_NAME, Field.ENTRY_CLASS_PK, Field.UID);
+			});
+	}
+
+	@Deactivate
+	protected void deactivate() {
+		_serviceRegistration.unregister();
+	}
+
+	@Reference
+	protected ModelSearchRegistrarHelper modelSearchRegistrarHelper;
+
+	private ServiceRegistration<?> _serviceRegistration;
+
+}

--- a/modules/apps/asset/asset-service/src/main/java/com/liferay/asset/internal/search/AssetEntrySearcher.java
+++ b/modules/apps/asset/asset-service/src/main/java/com/liferay/asset/internal/search/AssetEntrySearcher.java
@@ -1,0 +1,47 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.asset.internal.search;
+
+import com.liferay.asset.kernel.model.AssetEntry;
+import com.liferay.portal.kernel.search.BaseSearcher;
+import com.liferay.portal.kernel.search.Field;
+
+import org.osgi.service.component.annotations.Component;
+
+/**
+ * @author Brian Wing Shun Chan
+ * @author Julio Camarero
+ * @author Vagner B.C
+ */
+@Component(
+	immediate = true,
+	property = "model.class.name=com.liferay.asset.kernel.model.AssetEntry",
+	service = BaseSearcher.class
+)
+public class AssetEntrySearcher extends BaseSearcher {
+
+	public static final String CLASS_NAME = AssetEntry.class.getName();
+
+	public AssetEntrySearcher() {
+		setDefaultSelectedFieldNames(
+			Field.ENTRY_CLASS_NAME, Field.ENTRY_CLASS_PK, Field.UID);
+	}
+
+	@Override
+	public String getClassName() {
+		return CLASS_NAME;
+	}
+
+}

--- a/modules/apps/asset/asset-service/src/main/java/com/liferay/asset/internal/search/spi/model/index/contributor/AssetEntryModelDocumentContributor.java
+++ b/modules/apps/asset/asset-service/src/main/java/com/liferay/asset/internal/search/spi/model/index/contributor/AssetEntryModelDocumentContributor.java
@@ -1,0 +1,40 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.asset.internal.search.spi.model.index.contributor;
+
+import com.liferay.asset.kernel.model.AssetEntry;
+import com.liferay.portal.kernel.search.Document;
+import com.liferay.portal.search.spi.model.index.contributor.ModelDocumentContributor;
+
+import org.osgi.service.component.annotations.Component;
+
+/**
+ * @author Brian Wing Shun Chan
+ * @author Julio Camarero
+ * @author Vagner B.C
+ */
+@Component(
+	immediate = true,
+	property = "model.class.name=com.liferay.asset.kernel.model.AssetEntry",
+	service = ModelDocumentContributor.class
+)
+public class AssetEntryModelDocumentContributor
+	implements ModelDocumentContributor<AssetEntry> {
+
+	@Override
+	public void contribute(Document document, AssetEntry baseModel) {
+	}
+
+}

--- a/modules/apps/asset/asset-service/src/main/java/com/liferay/asset/internal/search/spi/model/query/contributer/AssetEntryKeywordQueryContributor.java
+++ b/modules/apps/asset/asset-service/src/main/java/com/liferay/asset/internal/search/spi/model/query/contributer/AssetEntryKeywordQueryContributor.java
@@ -1,0 +1,63 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.asset.internal.search.spi.model.query.contributer;
+
+import com.liferay.portal.kernel.search.BooleanQuery;
+import com.liferay.portal.kernel.search.Field;
+import com.liferay.portal.kernel.search.SearchContext;
+import com.liferay.portal.search.query.QueryHelper;
+import com.liferay.portal.search.spi.model.query.contributor.KeywordQueryContributor;
+import com.liferay.portal.search.spi.model.query.contributor.helper.KeywordQueryContributorHelper;
+
+import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.Reference;
+
+/**
+ * @author Brian Wing Shun Chan
+ * @author Julio Camarero
+ * @author Vagner B.C
+ */
+@Component(
+	immediate = true,
+	property = "indexer.class.name=com.liferay.asset.kernel.model.AssetEntry",
+	service = KeywordQueryContributor.class
+)
+public class AssetEntryKeywordQueryContributor
+	implements KeywordQueryContributor {
+
+	@Override
+	public void contribute(
+		String keywords, BooleanQuery booleanQuery,
+		KeywordQueryContributorHelper keywordQueryContributorHelper) {
+
+		SearchContext searchContext =
+			keywordQueryContributorHelper.getSearchContext();
+
+		if (searchContext.getAttributes() == null) {
+			return;
+		}
+
+		queryHelper.addSearchTerm(
+			booleanQuery, searchContext, Field.DESCRIPTION, false);
+		queryHelper.addSearchTerm(
+			booleanQuery, searchContext, Field.TITLE, false);
+		queryHelper.addSearchTerm(
+			booleanQuery, searchContext, Field.USER_NAME, false);
+	}
+
+	@Reference
+	protected QueryHelper queryHelper;
+
+}


### PR DESCRIPTION
The AssetEntryIndexer has only the postProcessSearchQuery method.

I deprecated the old AssetEntryIndexer and migrated to a new indexer mode.