### PR TITLE
LPS-86736 Create tests for ConfigurationModelIndexer

### DIFF
--- a/modules/apps/configuration-admin/configuration-admin-test/bnd.bnd
+++ b/modules/apps/configuration-admin/configuration-admin-test/bnd.bnd
@@ -1,3 +1,5 @@
 Bundle-Name: Liferay Configuration Admin Test
 Bundle-SymbolicName: com.liferay.configuration.admin.test
 Bundle-Version: 1.0.0
+-includeresource: test-classes/integration
+-metatype: *

--- a/modules/apps/configuration-admin/configuration-admin-test/build.gradle
+++ b/modules/apps/configuration-admin/configuration-admin-test/build.gradle
@@ -1,7 +1,11 @@
 dependencies {
 	testIntegrationCompile group: "com.liferay.portal", name: "com.liferay.portal.kernel", version: "default"
 	testIntegrationCompile project(":apps:configuration-admin:configuration-admin-api")
+	testIntegrationCompile project(":apps:configuration-admin:configuration-admin-web")
+	testIntegrationCompile project(":apps:portal-search:portal-search-test-util")
 	testIntegrationCompile project(":apps:static:osgi:osgi-util")
 	testIntegrationCompile project(":apps:static:portal-configuration:portal-configuration-metatype-api")
+	testIntegrationCompile project(":apps:users-admin:users-admin-test-util")
+	testIntegrationCompile project(":core:petra:petra-string")
 	testIntegrationCompile project(":test:arquillian-extension-junit-bridge")
 }

--- a/modules/apps/configuration-admin/configuration-admin-test/src/testIntegration/java/com/liferay/configuration/admin/internal/search/test/ConfigurationModelFixture.java
+++ b/modules/apps/configuration-admin/configuration-admin-test/src/testIntegration/java/com/liferay/configuration/admin/internal/search/test/ConfigurationModelFixture.java
@@ -1,0 +1,241 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.configuration.admin.internal.search.test;
+
+import aQute.bnd.annotation.metatype.Meta;
+
+import com.liferay.configuration.admin.category.ConfigurationCategory;
+import com.liferay.configuration.admin.web.internal.model.ConfigurationModel;
+import com.liferay.configuration.admin.web.internal.search.FieldNames;
+import com.liferay.configuration.admin.web.internal.util.ConfigurationEntryRetriever;
+import com.liferay.configuration.admin.web.internal.util.ConfigurationModelRetriever;
+import com.liferay.configuration.admin.web.internal.util.ResourceBundleLoaderProvider;
+import com.liferay.petra.string.StringPool;
+import com.liferay.portal.kernel.language.LanguageUtil;
+import com.liferay.portal.kernel.model.Group;
+import com.liferay.portal.kernel.search.Field;
+import com.liferay.portal.kernel.test.util.GroupTestUtil;
+import com.liferay.portal.kernel.util.GetterUtil;
+import com.liferay.portal.kernel.util.LocaleUtil;
+import com.liferay.portal.kernel.util.ResourceBundleLoader;
+import com.liferay.portal.kernel.util.ResourceBundleUtil;
+import com.liferay.portal.kernel.util.StringUtil;
+import com.liferay.portal.kernel.util.Validator;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Optional;
+import java.util.ResourceBundle;
+import java.util.stream.Stream;
+
+import org.osgi.framework.Bundle;
+import org.osgi.framework.FrameworkUtil;
+import org.osgi.service.metatype.AttributeDefinition;
+import org.osgi.service.metatype.ObjectClassDefinition;
+
+/**
+ * @author Vagner B.C
+ */
+public class ConfigurationModelFixture {
+
+	public ConfigurationModelFixture(
+		Group group, ConfigurationModelRetriever configurationModelRetriever,
+		ConfigurationEntryRetriever configurationEntryRetriever,
+		ResourceBundleLoaderProvider resourceBundleLoaderProvider) {
+
+		_group = group;
+		_configurationModelRetriever = configurationModelRetriever;
+		_configurationEntryRetriever = configurationEntryRetriever;
+		_resourceBundleLoaderProvider = resourceBundleLoaderProvider;
+	}
+
+	public Collection<ConfigurationModel> getConfigurationModels() {
+		return _configurationModels;
+	}
+
+	public void updateDisplaySettings(Locale locale) throws Exception {
+		Group group = GroupTestUtil.updateDisplaySettings(
+			_group.getGroupId(), null, locale);
+
+		_group.setModelAttributes(group.getModelAttributes());
+	}
+
+	public ConfigurationModel getConfigurationModel() {
+		Bundle bundle = FrameworkUtil.getBundle(
+			ConfigurationModelFixture.class);
+
+		Map<String, ConfigurationModel> configurationModels =
+			_configurationModelRetriever.getConfigurationModels(bundle);
+
+		_configurationModels = configurationModels.values();
+
+		Stream<ConfigurationModel> stream = _configurationModels.stream();
+
+		Optional<ConfigurationModel> optional = stream.findFirst();
+
+		return optional.get();
+	}
+
+	public void populateConfigurationAttributes(
+		ConfigurationModel configurationModel, Map<String, String> map) {
+
+		AttributeDefinition[] requiredAttributeDefinitions =
+			configurationModel.getAttributeDefinitions(
+				ObjectClassDefinition.ALL);
+
+		List<String> attributeNames = new ArrayList<>(
+			requiredAttributeDefinitions.length);
+
+		List<String> attributeDescriptions = new ArrayList<>(
+			requiredAttributeDefinitions.length);
+
+		for (AttributeDefinition attributeDefinition :
+				requiredAttributeDefinitions) {
+
+			String name = attributeDefinition.getName();
+			String description = attributeDefinition.getDescription();
+
+			if (name != null) {
+				attributeNames.add(name);
+			}
+
+			if (description != null) {
+				attributeDescriptions.add(description);
+			}
+		}
+
+		if (!attributeNames.isEmpty()) {
+			map.put(
+				FieldNames.CONFIGURATION_MODEL_ATTRIBUTE_NAME,
+				attributeNames.toString());
+		}
+
+		if (!attributeDescriptions.isEmpty()) {
+			map.put(
+				FieldNames.CONFIGURATION_MODEL_ATTRIBUTE_DESCRIPTION,
+				attributeDescriptions.toString());
+		}
+	}
+
+	public void populateTranslationTitleAndDescription(
+		ConfigurationModel configurationModel, Map<String, String> map) {
+
+		ResourceBundleLoader resourceBundleLoader =
+			_resourceBundleLoaderProvider.getResourceBundleLoader(
+				configurationModel.getBundleSymbolicName());
+
+		List<TranslationHelper> translationHelpers = new ArrayList<>(3);
+
+		ConfigurationCategory configurationCategory =
+			_configurationEntryRetriever.getConfigurationCategory(
+				configurationModel.getCategory());
+
+		if (configurationCategory != null) {
+			translationHelpers.add(
+				new TranslationHelper(
+					"category." + configurationModel.getCategory(),
+					FieldNames.CONFIGURATION_CATEGORY));
+		}
+
+		translationHelpers.add(
+			new TranslationHelper(
+				configurationModel.getDescription(), Field.DESCRIPTION));
+		translationHelpers.add(
+			new TranslationHelper(configurationModel.getName(), Field.TITLE));
+
+		ResourceBundle defaultResourceBundle =
+			resourceBundleLoader.loadResourceBundle(LocaleUtil.getDefault());
+
+		for (Locale locale : LanguageUtil.getAvailableLocales()) {
+			ResourceBundle resourceBundle =
+				resourceBundleLoader.loadResourceBundle(locale);
+
+			for (TranslationHelper translationHelper : translationHelpers) {
+				if (resourceBundle != null) {
+					translationHelper.accept(resourceBundle, locale);
+				}
+				else if (defaultResourceBundle != null) {
+					translationHelper.accept(defaultResourceBundle, locale);
+				}
+			}
+		}
+
+		for (TranslationHelper translationHelper : translationHelpers) {
+			String name = translationHelper._name;
+
+			translationHelper._values.forEach(
+				(locale, s) -> {
+					map.put(name + StringPool.UNDERLINE + locale.toString(), s);
+				});
+		}
+
+		map.put(
+			Field.DESCRIPTION,
+			StringUtil.upperCaseFirstLetter(
+				configurationModel.getDescription()));
+
+		map.put(
+			Field.TITLE,
+			StringUtil.upperCaseFirstLetter(configurationModel.getName()));
+	}
+
+	private final Group _group;
+	private final ConfigurationModelRetriever _configurationModelRetriever;
+	private Collection<ConfigurationModel> _configurationModels =
+		new ArrayList<>();
+	private final ConfigurationEntryRetriever _configurationEntryRetriever;
+	private final ResourceBundleLoaderProvider _resourceBundleLoaderProvider;
+
+	@Meta.OCD(
+		description = "description",
+		id = "com.liferay.configuration.admin.internal.search.test.ConfigurationModelFixture",
+		name = "name"
+	)
+	private interface TestConfiguration {
+
+		@Meta.AD
+		public String key1();
+
+		@Meta.AD
+		public String key2();
+
+	}
+
+	private static class TranslationHelper {
+
+		public void accept(ResourceBundle resourceBundle, Locale locale) {
+			String value = ResourceBundleUtil.getString(resourceBundle, _key);
+
+			if (Validator.isNotNull(value)) {
+				_values.put(locale, value);
+			}
+		}
+
+		private TranslationHelper(String key, String name) {
+			_key = GetterUtil.getString(key);
+			_name = name;
+		}
+
+		private final String _key;
+		private final String _name;
+		private final Map<Locale, String> _values = new HashMap<>();
+
+	}
+
+}

--- a/modules/apps/configuration-admin/configuration-admin-test/src/testIntegration/java/com/liferay/configuration/admin/internal/search/test/ConfigurationModelIndexerIndexedFieldsTest.java
+++ b/modules/apps/configuration-admin/configuration-admin-test/src/testIntegration/java/com/liferay/configuration/admin/internal/search/test/ConfigurationModelIndexerIndexedFieldsTest.java
@@ -1,0 +1,212 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.configuration.admin.internal.search.test;
+
+import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
+import com.liferay.configuration.admin.constants.ConfigurationAdminPortletKeys;
+import com.liferay.configuration.admin.web.internal.model.ConfigurationModel;
+import com.liferay.configuration.admin.web.internal.search.FieldNames;
+import com.liferay.configuration.admin.web.internal.util.ConfigurationEntryRetriever;
+import com.liferay.configuration.admin.web.internal.util.ConfigurationModelRetriever;
+import com.liferay.configuration.admin.web.internal.util.ResourceBundleLoaderProvider;
+import com.liferay.portal.kernel.model.CompanyConstants;
+import com.liferay.portal.kernel.model.Group;
+import com.liferay.portal.kernel.model.User;
+import com.liferay.portal.kernel.search.Document;
+import com.liferay.portal.kernel.search.Field;
+import com.liferay.portal.kernel.search.SearchEngineHelper;
+import com.liferay.portal.kernel.security.auth.CompanyThreadLocal;
+import com.liferay.portal.kernel.service.ResourcePermissionLocalService;
+import com.liferay.portal.kernel.test.rule.AggregateTestRule;
+import com.liferay.portal.kernel.test.rule.DeleteAfterTestRun;
+import com.liferay.portal.kernel.test.rule.SynchronousDestinationTestRule;
+import com.liferay.portal.kernel.util.LocaleThreadLocal;
+import com.liferay.portal.kernel.util.LocaleUtil;
+import com.liferay.portal.search.test.util.FieldValuesAssert;
+import com.liferay.portal.search.test.util.IndexedFieldsFixture;
+import com.liferay.portal.search.test.util.IndexerFixture;
+import com.liferay.portal.test.rule.Inject;
+import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
+import com.liferay.portal.test.rule.PermissionCheckerTestRule;
+import com.liferay.users.admin.test.util.search.UserSearchFixture;
+
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+/**
+ * @author Vagner B.C
+ */
+@RunWith(Arquillian.class)
+public class ConfigurationModelIndexerIndexedFieldsTest {
+
+	@ClassRule
+	@Rule
+	public static final AggregateTestRule aggregateTestRule =
+		new AggregateTestRule(
+			new LiferayIntegrationTestRule(),
+			PermissionCheckerTestRule.INSTANCE,
+			SynchronousDestinationTestRule.INSTANCE);
+
+	@Before
+	public void setUp() throws Exception {
+		setUpUserSearchFixture();
+
+		setUpConfigurationModelFixture();
+		setUpConfigurationModelIndexerFixture();
+
+		setUpIndexedFieldsFixture();
+
+		defaultLocale = LocaleThreadLocal.getDefaultLocale();
+	}
+
+	@After
+	public void tearDown() {
+		LocaleThreadLocal.setDefaultLocale(defaultLocale);
+	}
+
+	@Test
+	public void testIndexedFields() throws Exception {
+		Locale locale = LocaleUtil.JAPAN;
+
+		setTestLocale(locale);
+
+		configurationModelFixture.updateDisplaySettings(locale);
+
+		ConfigurationModel configurationModel =
+			configurationModelFixture.getConfigurationModel();
+
+		String searchTerm = "説明";
+
+		Document document = configurationModelIndexerFixture.searchOnlyOne(
+			searchTerm, locale, CompanyConstants.SYSTEM);
+
+		indexedFieldsFixture.postProcessDocument(document);
+
+		FieldValuesAssert.assertFieldValues(
+			expectedFieldValues(configurationModel), document, searchTerm);
+	}
+
+	protected Map<String, String> expectedFieldValues(
+			ConfigurationModel configurationModel)
+		throws Exception {
+
+		Map<String, String> map = new HashMap<>();
+
+		map.put(Field.COMPANY_ID, String.valueOf(CompanyConstants.SYSTEM));
+
+		map.put(
+			FieldNames.CONFIGURATION_MODEL_FACTORY_PID,
+			configurationModel.getFactoryPid());
+
+		map.put(FieldNames.CONFIGURATION_MODEL_ID, configurationModel.getID());
+
+		map.put(Field.ENTRY_CLASS_NAME, ConfigurationModel.class.getName());
+
+		map.put(
+			Field.UID,
+			ConfigurationAdminPortletKeys.SYSTEM_SETTINGS + "_PORTLET_" +
+				configurationModel.getID());
+
+		configurationModelFixture.populateConfigurationAttributes(
+			configurationModel, map);
+
+		configurationModelFixture.populateTranslationTitleAndDescription(
+			configurationModel, map);
+
+		return map;
+	}
+
+	protected void setTestLocale(Locale locale) throws Exception {
+		configurationModelFixture.updateDisplaySettings(locale);
+		LocaleThreadLocal.setDefaultLocale(locale);
+	}
+
+	protected void setUpConfigurationModelFixture() {
+		configurationModelFixture = new ConfigurationModelFixture(
+			group, configurationModelRetriever, configurationEntryRetriever,
+			resourceBundleLoaderProvider);
+
+		_configurationModels =
+			configurationModelFixture.getConfigurationModels();
+	}
+
+	protected void setUpConfigurationModelIndexerFixture() {
+		configurationModelIndexerFixture = new IndexerFixture<>(
+			ConfigurationModel.class);
+	}
+
+	protected void setUpIndexedFieldsFixture() {
+		indexedFieldsFixture = new IndexedFieldsFixture(
+			resourcePermissionLocalService, searchEngineHelper);
+	}
+
+	protected void setUpUserSearchFixture() throws Exception {
+		userSearchFixture = new UserSearchFixture();
+
+		userSearchFixture.setUp();
+
+		_groups = userSearchFixture.getGroups();
+		_users = userSearchFixture.getUsers();
+
+		group = userSearchFixture.addGroup();
+
+		CompanyThreadLocal.setCompanyId(CompanyConstants.SYSTEM);
+	}
+
+	@Inject
+	protected ConfigurationEntryRetriever configurationEntryRetriever;
+
+	protected ConfigurationModelFixture configurationModelFixture;
+	protected IndexerFixture<ConfigurationModel>
+		configurationModelIndexerFixture;
+
+	@Inject
+	protected ConfigurationModelRetriever configurationModelRetriever;
+
+	protected Locale defaultLocale;
+	protected Group group;
+	protected IndexedFieldsFixture indexedFieldsFixture;
+
+	@Inject
+	protected ResourceBundleLoaderProvider resourceBundleLoaderProvider;
+
+	@Inject
+	protected ResourcePermissionLocalService resourcePermissionLocalService;
+
+	@Inject
+	protected SearchEngineHelper searchEngineHelper;
+
+	protected UserSearchFixture userSearchFixture;
+
+	@DeleteAfterTestRun
+	private Collection<ConfigurationModel> _configurationModels;
+
+	@DeleteAfterTestRun
+	private List<Group> _groups;
+
+	@DeleteAfterTestRun
+	private List<User> _users;
+
+}

--- a/modules/apps/configuration-admin/configuration-admin-test/src/testIntegration/java/com/liferay/configuration/admin/internal/search/test/ConfigurationModelIndexerReindexTest.java
+++ b/modules/apps/configuration-admin/configuration-admin-test/src/testIntegration/java/com/liferay/configuration/admin/internal/search/test/ConfigurationModelIndexerReindexTest.java
@@ -1,0 +1,141 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.configuration.admin.internal.search.test;
+
+import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
+import com.liferay.configuration.admin.web.internal.model.ConfigurationModel;
+import com.liferay.configuration.admin.web.internal.util.ConfigurationEntryRetriever;
+import com.liferay.configuration.admin.web.internal.util.ConfigurationModelRetriever;
+import com.liferay.configuration.admin.web.internal.util.ResourceBundleLoaderProvider;
+import com.liferay.portal.kernel.model.CompanyConstants;
+import com.liferay.portal.kernel.model.Group;
+import com.liferay.portal.kernel.model.User;
+import com.liferay.portal.kernel.search.Document;
+import com.liferay.portal.kernel.security.auth.CompanyThreadLocal;
+import com.liferay.portal.kernel.test.rule.AggregateTestRule;
+import com.liferay.portal.kernel.test.rule.DeleteAfterTestRun;
+import com.liferay.portal.kernel.test.rule.SynchronousDestinationTestRule;
+import com.liferay.portal.search.test.util.IndexerFixture;
+import com.liferay.portal.test.rule.Inject;
+import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
+import com.liferay.portal.test.rule.PermissionCheckerTestRule;
+import com.liferay.users.admin.test.util.search.UserSearchFixture;
+
+import java.util.Collection;
+import java.util.List;
+
+import org.junit.Before;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+/**
+ * @author Vagner B.C
+ */
+@RunWith(Arquillian.class)
+public class ConfigurationModelIndexerReindexTest {
+
+	@ClassRule
+	@Rule
+	public static final AggregateTestRule aggregateTestRule =
+		new AggregateTestRule(
+			new LiferayIntegrationTestRule(),
+			PermissionCheckerTestRule.INSTANCE,
+			SynchronousDestinationTestRule.INSTANCE);
+
+	@Before
+	public void setUp() throws Exception {
+		setUpUserSearchFixture();
+		setUpConfigurationModelFixture();
+		setUpConfigurationModelIndexerFixture();
+	}
+
+	@Test
+	public void testReindexing() throws Exception {
+		ConfigurationModel configurationModel =
+			configurationModelFixture.getConfigurationModel();
+
+		String searchTerm = configurationModel.getFactoryPid();
+
+		Document document = configurationModelIndexerFixture.searchOnlyOne(
+			searchTerm, null, CompanyConstants.SYSTEM);
+
+		configurationModelIndexerFixture.deleteDocument(
+			document, CompanyConstants.SYSTEM);
+
+		configurationModelIndexerFixture.searchNoOne(
+			searchTerm, null, CompanyConstants.SYSTEM);
+
+		configurationModelIndexerFixture.reindex(CompanyConstants.SYSTEM);
+
+		configurationModelIndexerFixture.searchOnlyOne(
+			searchTerm, null, CompanyConstants.SYSTEM);
+	}
+
+	protected void setUpConfigurationModelFixture() {
+		configurationModelFixture = new ConfigurationModelFixture(
+			group, configurationModelRetriever, configurationEntryRetriever,
+			resourceBundleLoaderProvider);
+
+		_configurationModels =
+			configurationModelFixture.getConfigurationModels();
+	}
+
+	protected void setUpConfigurationModelIndexerFixture() {
+		configurationModelIndexerFixture = new IndexerFixture<>(
+			ConfigurationModel.class);
+	}
+
+	protected void setUpUserSearchFixture() throws Exception {
+		userSearchFixture = new UserSearchFixture();
+
+		userSearchFixture.setUp();
+
+		_groups = userSearchFixture.getGroups();
+		_users = userSearchFixture.getUsers();
+
+		group = userSearchFixture.addGroup();
+
+		CompanyThreadLocal.setCompanyId(CompanyConstants.SYSTEM);
+	}
+
+	@Inject
+	protected ConfigurationEntryRetriever configurationEntryRetriever;
+
+	protected ConfigurationModelFixture configurationModelFixture;
+	protected IndexerFixture<ConfigurationModel>
+		configurationModelIndexerFixture;
+
+	@Inject
+	protected ConfigurationModelRetriever configurationModelRetriever;
+
+	protected Group group;
+
+	@Inject
+	protected ResourceBundleLoaderProvider resourceBundleLoaderProvider;
+
+	protected UserSearchFixture userSearchFixture;
+
+	@DeleteAfterTestRun
+	private Collection<ConfigurationModel> _configurationModels;
+
+	@DeleteAfterTestRun
+	private List<Group> _groups;
+
+	@DeleteAfterTestRun
+	private List<User> _users;
+
+}

--- a/modules/apps/configuration-admin/configuration-admin-web/bnd.bnd
+++ b/modules/apps/configuration-admin/configuration-admin-web/bnd.bnd
@@ -1,4 +1,7 @@
 Bundle-Name: Liferay Configuration Admin Web
 Bundle-SymbolicName: com.liferay.configuration.admin.web
 Bundle-Version: 3.0.0
+Export-Package:\
+	com.liferay.configuration.admin.web.internal.model,\
+	com.liferay.configuration.admin.web.internal.util
 -includeresource: @org.apache.felix.fileinstall-[0-9]*.jar!/org/apache/felix/cm/file/ConfigurationHandler.class

--- a/modules/apps/portal-search/portal-search-test-util/src/main/java/com/liferay/portal/search/test/util/IndexerFixture.java
+++ b/modules/apps/portal-search/portal-search-test-util/src/main/java/com/liferay/portal/search/test/util/IndexerFixture.java
@@ -53,6 +53,17 @@ public class IndexerFixture<T> {
 		}
 	}
 
+	public void deleteDocument(Document document, long companyId) {
+		try {
+			IndexWriterHelperUtil.deleteDocument(
+				_indexer.getSearchEngineId(), companyId, document.getUID(),
+				true);
+		}
+		catch (PortalException pe) {
+			throw new RuntimeException(pe);
+		}
+	}
+
 	public void deleteDocuments(Document[] docs) {
 		try {
 			Stream<Document> stream = Arrays.stream(docs);
@@ -100,22 +111,28 @@ public class IndexerFixture<T> {
 		}
 	}
 
-	public void searchNoOne(long userId, String keywords, Locale locale) {
-		searchNoOne(userId, keywords, locale, null);
-	}
-
 	public void searchNoOne(
-		long userId, String keywords, Locale locale,
+		long userId, long companyId, String keywords, Locale locale,
 		Map<String, Serializable> attributes) {
 
 		try {
 			SearchContext searchContext =
 				SearchContextTestUtil.getSearchContext(
-					userId, null, keywords, locale, attributes);
+					userId, companyId, null, keywords, locale, attributes);
 
 			Hits hits = _indexer.search(searchContext);
 
 			HitsAssert.assertNoHits(hits);
+		}
+		catch (PortalException pe) {
+			throw new RuntimeException(pe);
+		}
+	}
+
+	public void searchNoOne(long userId, String keywords, Locale locale) {
+		try {
+			searchNoOne(
+				userId, TestPropsValues.getCompanyId(), keywords, locale, null);
 		}
 		catch (PortalException pe) {
 			throw new RuntimeException(pe);
@@ -130,12 +147,41 @@ public class IndexerFixture<T> {
 		searchNoOne(keywords, locale, null);
 	}
 
+	public void searchNoOne(String keywords, Locale locale, long company) {
+		try {
+			searchNoOne(
+				TestPropsValues.getUserId(), company, keywords, locale, null);
+		}
+		catch (PortalException pe) {
+			throw new RuntimeException(pe);
+		}
+	}
+
 	public void searchNoOne(
 		String keywords, Locale locale, Map<String, Serializable> attributes) {
 
 		try {
 			searchNoOne(
-				TestPropsValues.getUserId(), keywords, locale, attributes);
+				TestPropsValues.getUserId(), TestPropsValues.getCompanyId(),
+				keywords, locale, attributes);
+		}
+		catch (PortalException pe) {
+			throw new RuntimeException(pe);
+		}
+	}
+
+	public Document searchOnlyOne(
+		long userId, long companyId, String keywords, Locale locale,
+		Map<String, Serializable> attributes) {
+
+		try {
+			SearchContext searchContext =
+				SearchContextTestUtil.getSearchContext(
+					userId, companyId, null, keywords, locale, attributes);
+
+			Hits hits = _indexer.search(searchContext);
+
+			return HitsAssert.assertOnlyOne(hits);
 		}
 		catch (PortalException pe) {
 			throw new RuntimeException(pe);
@@ -143,21 +189,9 @@ public class IndexerFixture<T> {
 	}
 
 	public Document searchOnlyOne(long userId, String keywords, Locale locale) {
-		return searchOnlyOne(userId, keywords, locale, null);
-	}
-
-	public Document searchOnlyOne(
-		long userId, String keywords, Locale locale,
-		Map<String, Serializable> attributes) {
-
 		try {
-			SearchContext searchContext =
-				SearchContextTestUtil.getSearchContext(
-					userId, null, keywords, locale, attributes);
-
-			Hits hits = _indexer.search(searchContext);
-
-			return HitsAssert.assertOnlyOne(hits);
+			return searchOnlyOne(
+				userId, TestPropsValues.getCompanyId(), keywords, locale, null);
 		}
 		catch (PortalException pe) {
 			throw new RuntimeException(pe);
@@ -173,11 +207,24 @@ public class IndexerFixture<T> {
 	}
 
 	public Document searchOnlyOne(
+		String keywords, Locale locale, long company) {
+
+		try {
+			return searchOnlyOne(
+				TestPropsValues.getUserId(), company, keywords, locale, null);
+		}
+		catch (PortalException pe) {
+			throw new RuntimeException(pe);
+		}
+	}
+
+	public Document searchOnlyOne(
 		String keywords, Locale locale, Map<String, Serializable> attributes) {
 
 		try {
 			return searchOnlyOne(
-				TestPropsValues.getUserId(), keywords, locale, attributes);
+				TestPropsValues.getUserId(), TestPropsValues.getCompanyId(),
+				keywords, locale, attributes);
 		}
 		catch (PortalException pe) {
 			throw new RuntimeException(pe);

--- a/modules/apps/portal-search/portal-search-test-util/src/main/java/com/liferay/portal/search/test/util/SearchContextTestUtil.java
+++ b/modules/apps/portal-search/portal-search-test-util/src/main/java/com/liferay/portal/search/test/util/SearchContextTestUtil.java
@@ -38,8 +38,38 @@ public class SearchContextTestUtil {
 		throws Exception {
 
 		return getSearchContext(
-			TestPropsValues.getUserId(), new long[] {groupId}, StringPool.BLANK,
-			null, null);
+			TestPropsValues.getUserId(), TestPropsValues.getCompanyId(),
+			new long[] {groupId}, StringPool.BLANK, null, null);
+	}
+
+	public static SearchContext getSearchContext(
+		long userId, long companyId, long[] groupIds, String keywords,
+		Locale locale, boolean highlightEnabled,
+		Map<String, Serializable> attributes) {
+
+		SearchContext searchContext = new SearchContext();
+
+		searchContext.setAttributes(attributes);
+		searchContext.setCompanyId(companyId);
+		searchContext.setKeywords(keywords);
+		searchContext.setGroupIds(groupIds);
+		searchContext.setLocale(locale);
+		searchContext.setUserId(userId);
+
+		QueryConfig queryConfig = searchContext.getQueryConfig();
+
+		queryConfig.setHighlightEnabled(highlightEnabled);
+		queryConfig.setSelectedFieldNames(StringPool.STAR);
+
+		return searchContext;
+	}
+
+	public static SearchContext getSearchContext(
+		long userId, long companyId, long[] groupIds, String keywords,
+		Locale locale, Map<String, Serializable> attributes) {
+
+		return getSearchContext(
+			userId, companyId, groupIds, keywords, locale, false, attributes);
 	}
 
 	public static SearchContext getSearchContext(
@@ -55,45 +85,17 @@ public class SearchContextTestUtil {
 		throws PortalException {
 
 		return getSearchContext(
-			userId, groupIds, keywords, locale, highlightEnabled, null);
-	}
-
-	public static SearchContext getSearchContext(
-			long userId, long[] groupIds, String keywords, Locale locale,
-			boolean highlightEnabled, Map<String, Serializable> attributes)
-		throws PortalException {
-
-		SearchContext searchContext = new SearchContext();
-
-		searchContext.setAttributes(attributes);
-		searchContext.setCompanyId(TestPropsValues.getCompanyId());
-		searchContext.setKeywords(keywords);
-		searchContext.setGroupIds(groupIds);
-		searchContext.setLocale(locale);
-		searchContext.setUserId(userId);
-
-		QueryConfig queryConfig = searchContext.getQueryConfig();
-
-		queryConfig.setHighlightEnabled(highlightEnabled);
-		queryConfig.setSelectedFieldNames(StringPool.STAR);
-
-		return searchContext;
-	}
-
-	public static SearchContext getSearchContext(
-			long userId, long[] groupIds, String keywords, Locale locale,
-			Map<String, Serializable> attributes)
-		throws PortalException {
-
-		return getSearchContext(
-			userId, groupIds, keywords, locale, false, attributes);
+			userId, TestPropsValues.getCompanyId(), groupIds, keywords, locale,
+			highlightEnabled, null);
 	}
 
 	public static SearchContext getSearchContext(
 			long userId, String keywords, Locale locale)
 		throws PortalException {
 
-		return getSearchContext(userId, null, keywords, locale, null);
+		return getSearchContext(
+			userId, TestPropsValues.getCompanyId(), null, keywords, locale,
+			null);
 	}
 
 }


### PR DESCRIPTION
Created only the tests.

The ConfigurationModel class does not implement "BaseModel", the migration does not work, since ModelDocumentContributor and ModelIndexerWriterContributor need a class that implements "BaseModel".