### PR TITLE
LPS-94598  Create JournalArticleMultiLanguageSearchJapaneseSummaryTest

### DIFF
--- a/modules/apps/journal/journal-service/src/main/java/com/liferay/journal/internal/search/JournalArticleIndexer.java
+++ b/modules/apps/journal/journal-service/src/main/java/com/liferay/journal/internal/search/JournalArticleIndexer.java
@@ -874,7 +874,7 @@ public class JournalArticleIndexer extends BaseIndexer<JournalArticle> {
 			content = HighlightUtil.highlight(
 				content, ArrayUtil.toStringArray(highlights),
 				HighlightUtil.HIGHLIGHT_TAG_OPEN,
-				HighlightUtil.HIGHLIGHT_TAG_CLOSE);
+				HighlightUtil.HIGHLIGHT_TAG_CLOSE, snippetLocale);
 		}
 		catch (Exception e) {
 			if (_log.isDebugEnabled()) {

--- a/modules/apps/journal/journal-test/src/testIntegration/java/com/liferay/journal/search/test/JournalArticleMultiLanguageSearchJapaneseSummaryTest.java
+++ b/modules/apps/journal/journal-test/src/testIntegration/java/com/liferay/journal/search/test/JournalArticleMultiLanguageSearchJapaneseSummaryTest.java
@@ -1,0 +1,219 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.journal.search.test;
+
+import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
+import com.liferay.journal.model.JournalArticle;
+import com.liferay.journal.service.JournalArticleLocalService;
+import com.liferay.journal.test.util.search.JournalArticleBlueprint;
+import com.liferay.journal.test.util.search.JournalArticleContent;
+import com.liferay.journal.test.util.search.JournalArticleSearchFixture;
+import com.liferay.journal.test.util.search.JournalArticleTitle;
+import com.liferay.petra.string.StringBundler;
+import com.liferay.petra.string.StringPool;
+import com.liferay.portal.kernel.model.Group;
+import com.liferay.portal.kernel.model.User;
+import com.liferay.portal.kernel.search.Document;
+import com.liferay.portal.kernel.search.Field;
+import com.liferay.portal.kernel.search.Indexer;
+import com.liferay.portal.kernel.search.IndexerRegistry;
+import com.liferay.portal.kernel.search.highlight.HighlightUtil;
+import com.liferay.portal.kernel.test.rule.AggregateTestRule;
+import com.liferay.portal.kernel.test.rule.DeleteAfterTestRun;
+import com.liferay.portal.kernel.test.util.RandomTestUtil;
+import com.liferay.portal.kernel.test.util.TestPropsValues;
+import com.liferay.portal.kernel.util.LocaleUtil;
+import com.liferay.portal.search.test.util.SummaryFixture;
+import com.liferay.portal.service.test.ServiceTestUtil;
+import com.liferay.portal.test.rule.Inject;
+import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
+import com.liferay.users.admin.test.util.search.UserSearchFixture;
+
+import java.util.List;
+import java.util.Locale;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+/**
+ * @author Vagner B.C
+ */
+@RunWith(Arquillian.class)
+public class JournalArticleMultiLanguageSearchJapaneseSummaryTest {
+
+	@ClassRule
+	@Rule
+	public static final AggregateTestRule aggregateTestRule =
+		new LiferayIntegrationTestRule();
+
+	@Before
+	public void setUp() throws Exception {
+		ServiceTestUtil.setUser(TestPropsValues.getUser());
+
+		_indexer = indexerRegistry.getIndexer(JournalArticle.class);
+
+		_journalArticleSearchFixture = new JournalArticleSearchFixture(
+			journalArticleLocalService);
+
+		_journalArticleSearchFixture.setUp();
+
+		_journalArticles = _journalArticleSearchFixture.getJournalArticles();
+
+		_userSearchFixture = new UserSearchFixture();
+
+		_userSearchFixture.setUp();
+
+		_groups = _userSearchFixture.getGroups();
+		_users = _userSearchFixture.getUsers();
+
+		_group = _userSearchFixture.addGroup();
+
+		_user = _userSearchFixture.addUser(
+			RandomTestUtil.randomString(), _group);
+
+		_summaryFixture = new SummaryFixture<>(
+			JournalArticle.class, _group, null, _user);
+	}
+
+	@After
+	public void tearDown() {
+		_journalArticleSearchFixture.tearDown();
+
+		_userSearchFixture.tearDown();
+	}
+
+	@Test
+	public void testJapaneseSummaryHighlightedTermWithoutWordBoundaries()
+		throws Exception {
+
+		String highlightedContent = StringBundler.concat(
+			HighlightUtil.HIGHLIGHT_TAG_OPEN, "新規",
+			HighlightUtil.HIGHLIGHT_TAG_CLOSE, "作成");
+		String highlightedTitle = StringBundler.concat(
+			HighlightUtil.HIGHLIGHT_TAG_OPEN, "新規",
+			HighlightUtil.HIGHLIGHT_TAG_CLOSE, "作成");
+
+		testLocaleSummaryHighlighted(
+			LocaleUtil.JAPAN, "新規作成", "新規作成", highlightedTitle,
+			highlightedContent);
+	}
+
+	@Test
+	public void testJapaneseSummaryHighlightedTermWithWordBoundaries()
+		throws Exception {
+
+		String highlightedContent = StringBundler.concat(
+			"新規", HighlightUtil.HIGHLIGHT_TAG_OPEN, "作成",
+			HighlightUtil.HIGHLIGHT_TAG_CLOSE);
+		String highlightedTitle = StringBundler.concat(
+			"新規", HighlightUtil.HIGHLIGHT_TAG_OPEN, "作成",
+			HighlightUtil.HIGHLIGHT_TAG_CLOSE);
+
+		testLocaleSummaryHighlighted(
+			LocaleUtil.JAPAN, "新規作成", "新規作成", highlightedTitle,
+			highlightedContent);
+	}
+
+	protected JournalArticle addArticle(
+		String title, String content, Locale locale) {
+
+		return _journalArticleSearchFixture.addArticle(
+			new JournalArticleBlueprint() {
+				{
+					setGroupId(_group.getGroupId());
+					setJournalArticleContent(
+						new JournalArticleContent() {
+							{
+								put(locale, content);
+
+								setDefaultLocale(locale);
+								setName("content");
+							}
+						});
+					setJournalArticleTitle(
+						new JournalArticleTitle() {
+							{
+								put(locale, title);
+							}
+						});
+				}
+			});
+	}
+
+	protected Document getDocument(String title, String content, Locale locale)
+		throws Exception {
+
+		return _indexer.getDocument(addArticle(title, content, locale));
+	}
+
+	protected String getSnippetFieldName(String field, Locale locale) {
+		return StringBundler.concat(
+			Field.SNIPPET, StringPool.UNDERLINE, field, StringPool.UNDERLINE,
+			LocaleUtil.toLanguageId(locale));
+	}
+
+	protected void setSnippets(
+		String highlightedTitle, String highlightedContent, Document document,
+		Locale locale) {
+
+		document.addText(
+			getSnippetFieldName(Field.CONTENT, locale), highlightedContent);
+		document.addText(
+			getSnippetFieldName(Field.TITLE, locale), highlightedTitle);
+	}
+
+	protected void testLocaleSummaryHighlighted(
+			Locale locale, String title, String content,
+			String highlightedTitle, String highlightedContent)
+		throws Exception {
+
+		Document document = getDocument(title, content, locale);
+
+		setSnippets(highlightedTitle, highlightedContent, document, locale);
+
+		_summaryFixture.assertSummary(
+			highlightedTitle, highlightedContent, document);
+	}
+
+	@Inject
+	protected IndexerRegistry indexerRegistry;
+
+	@Inject
+	protected JournalArticleLocalService journalArticleLocalService;
+
+	private Group _group;
+
+	@DeleteAfterTestRun
+	private List<Group> _groups;
+
+	private Indexer<JournalArticle> _indexer;
+
+	@DeleteAfterTestRun
+	private List<JournalArticle> _journalArticles;
+
+	private JournalArticleSearchFixture _journalArticleSearchFixture;
+	private SummaryFixture<JournalArticle> _summaryFixture;
+	private User _user;
+
+	@DeleteAfterTestRun
+	private List<User> _users;
+
+	private UserSearchFixture _userSearchFixture;
+
+}

--- a/modules/apps/layout/layout-impl/src/main/java/com/liferay/layout/internal/search/LayoutIndexer.java
+++ b/modules/apps/layout/layout-impl/src/main/java/com/liferay/layout/internal/search/LayoutIndexer.java
@@ -227,8 +227,8 @@ public class LayoutIndexer extends BaseIndexer<Layout> {
 
 		content = HighlightUtil.highlight(
 			content, ArrayUtil.toStringArray(highlights),
-			HighlightUtil.HIGHLIGHT_TAG_OPEN,
-			HighlightUtil.HIGHLIGHT_TAG_CLOSE);
+			HighlightUtil.HIGHLIGHT_TAG_OPEN, HighlightUtil.HIGHLIGHT_TAG_CLOSE,
+			locale);
 
 		Summary summary = new Summary(locale, name, content);
 

--- a/modules/apps/layout/layout-impl/src/main/java/com/liferay/layout/internal/search/spi/model/result/contributor/LayoutModelSummaryContributor.java
+++ b/modules/apps/layout/layout-impl/src/main/java/com/liferay/layout/internal/search/spi/model/result/contributor/LayoutModelSummaryContributor.java
@@ -77,8 +77,8 @@ public class LayoutModelSummaryContributor implements ModelSummaryContributor {
 
 		content = HighlightUtil.highlight(
 			content, ArrayUtil.toStringArray(highlights),
-			HighlightUtil.HIGHLIGHT_TAG_OPEN,
-			HighlightUtil.HIGHLIGHT_TAG_CLOSE);
+			HighlightUtil.HIGHLIGHT_TAG_OPEN, HighlightUtil.HIGHLIGHT_TAG_CLOSE,
+			locale);
 
 		Summary summary = new Summary(locale, name, content);
 

--- a/portal-kernel/src/com/liferay/portal/kernel/search/Summary.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/search/Summary.java
@@ -146,7 +146,7 @@ public class Summary {
 
 		text = HighlightUtil.highlight(
 			text, _queryTerms, _ESCAPE_SAFE_HIGHLIGHTS[0],
-			_ESCAPE_SAFE_HIGHLIGHTS[1]);
+			_ESCAPE_SAFE_HIGHLIGHTS[1], _locale);
 
 		if (_escape) {
 			text = HtmlUtil.escape(text);

--- a/portal-kernel/src/com/liferay/portal/kernel/search/highlight/HighlightUtil.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/search/highlight/HighlightUtil.java
@@ -18,10 +18,14 @@ import com.liferay.petra.string.StringPool;
 import com.liferay.portal.kernel.search.Document;
 import com.liferay.portal.kernel.search.Field;
 import com.liferay.portal.kernel.util.ArrayUtil;
+import com.liferay.portal.kernel.util.LocaleUtil;
 import com.liferay.portal.kernel.util.StringBundler;
 import com.liferay.portal.kernel.util.StringUtil;
 import com.liferay.portal.kernel.util.Validator;
 
+import java.util.Arrays;
+import java.util.List;
+import java.util.Locale;
 import java.util.Set;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
@@ -38,6 +42,11 @@ public class HighlightUtil {
 	public static final String[] HIGHLIGHTS = {
 		"<span class=\"highlight\">", "</span>"
 	};
+
+	public static final List<Locale> nonBoundaryLocales = Arrays.asList(
+		LocaleUtil.JAPAN, LocaleUtil.JAPANESE, LocaleUtil.CHINA,
+		LocaleUtil.CHINESE, LocaleUtil.SIMPLIFIED_CHINESE,
+		LocaleUtil.TRADITIONAL_CHINESE);
 
 	public static void addSnippet(
 		Document document, Set<String> queryTerms, String snippet,
@@ -66,11 +75,12 @@ public class HighlightUtil {
 	}
 
 	public static String highlight(String s, String[] queryTerms) {
-		return highlight(s, queryTerms, HIGHLIGHTS[0], HIGHLIGHTS[1]);
+		return highlight(s, queryTerms, HIGHLIGHTS[0], HIGHLIGHTS[1], null);
 	}
 
 	public static String highlight(
-		String s, String[] queryTerms, String highlight1, String highlight2) {
+		String s, String[] queryTerms, String highlight1, String highlight2,
+		Locale locale) {
 
 		if (Validator.isBlank(s) || ArrayUtil.isEmpty(queryTerms)) {
 			return s;
@@ -85,7 +95,9 @@ public class HighlightUtil {
 
 			sb.append(Pattern.quote(queryTerms[i].trim()));
 
-			sb.append(_REGEXP_WORD_BOUNDARY);
+			if ((locale == null) || !nonBoundaryLocales.contains(locale)) {
+				sb.append(_REGEXP_WORD_BOUNDARY);
+			}
 		}
 
 		Pattern pattern = Pattern.compile(


### PR DESCRIPTION
https://issues.liferay.com/browse/LPS-84701

- Content used: **新規作成**
- Highlight used: **新規**
- com.liferay.portal.kernel.search.highlight.HighlightUtil linha: 88
     Regex that was created in the method highlight to get the highlight term used: **\Q新規\E\b**

* The problem is that Japanese is written / read from right to left and has no space character.
* The **"\b"** of the regex causes the word **"新規"** to not be found

**The possible solution is to add a locale parameter in the HighlightUtil.highlight () method and check if the language code is Japan or another that has the same respects (Chinese, etc.) to not add the bondary in the regex.**


**Solution 2 (Create a new module to host HighlightUtil) :**
https://github.com/brandizzi/liferay-portal/pull/716