### PR TITLE
LPS-94598 Solution 2: Create JournalArticleMultiLanguageSearchJapaneseSummaryTest

### DIFF
--- a/modules/apps/journal/journal-service/src/main/java/com/liferay/journal/internal/search/JournalArticleIndexer.java
+++ b/modules/apps/journal/journal-service/src/main/java/com/liferay/journal/internal/search/JournalArticleIndexer.java
@@ -61,7 +61,6 @@ import com.liferay.portal.kernel.search.Summary;
 import com.liferay.portal.kernel.search.filter.BooleanFilter;
 import com.liferay.portal.kernel.search.filter.QueryFilter;
 import com.liferay.portal.kernel.search.generic.BooleanQueryImpl;
-import com.liferay.portal.kernel.search.highlight.HighlightUtil;
 import com.liferay.portal.kernel.security.auth.CompanyThreadLocal;
 import com.liferay.portal.kernel.security.permission.ActionKeys;
 import com.liferay.portal.kernel.security.permission.PermissionChecker;
@@ -85,6 +84,7 @@ import com.liferay.portal.kernel.workflow.WorkflowConstants;
 import com.liferay.portal.search.batch.BatchIndexingHelper;
 import com.liferay.portal.search.filter.DateRangeFilterBuilder;
 import com.liferay.portal.search.filter.FilterBuilders;
+import com.liferay.portal.search.highlight.HighlightHelper;
 import com.liferay.portal.search.index.IndexStatusManager;
 import com.liferay.portal.search.localization.SearchLocalizationHelper;
 import com.liferay.trash.TrashHelper;
@@ -869,12 +869,12 @@ public class JournalArticleIndexer extends BaseIndexer<JournalArticle> {
 
 			Set<String> highlights = new HashSet<>();
 
-			HighlightUtil.addSnippet(document, highlights, snippet, "temp");
+			_highlightHelper.addSnippet(document, highlights, snippet, "temp");
 
-			content = HighlightUtil.highlight(
+			content = _highlightHelper.highlight(
 				content, ArrayUtil.toStringArray(highlights),
-				HighlightUtil.HIGHLIGHT_TAG_OPEN,
-				HighlightUtil.HIGHLIGHT_TAG_CLOSE);
+				HighlightHelper.HIGHLIGHT_TAG_OPEN,
+				HighlightHelper.HIGHLIGHT_TAG_CLOSE, snippetLocale);
 		}
 		catch (Exception e) {
 			if (_log.isDebugEnabled()) {
@@ -1059,7 +1059,7 @@ public class JournalArticleIndexer extends BaseIndexer<JournalArticle> {
 	};
 
 	private static final String[] _HIGHLIGHT_TAGS = {
-		HighlightUtil.HIGHLIGHT_TAG_OPEN, HighlightUtil.HIGHLIGHT_TAG_CLOSE
+		HighlightHelper.HIGHLIGHT_TAG_OPEN, HighlightHelper.HIGHLIGHT_TAG_CLOSE
 	};
 
 	private static final Log _log = LogFactoryUtil.getLog(
@@ -1075,6 +1075,9 @@ public class JournalArticleIndexer extends BaseIndexer<JournalArticle> {
 
 	@Reference
 	private FilterBuilders _filterBuilders;
+
+	@Reference
+	private HighlightHelper _highlightHelper;
 
 	@Reference
 	private Html _html;

--- a/modules/apps/journal/journal-test/src/testIntegration/java/com/liferay/journal/search/test/JournalArticleMultiLanguageSearchJapaneseSummaryTest.java
+++ b/modules/apps/journal/journal-test/src/testIntegration/java/com/liferay/journal/search/test/JournalArticleMultiLanguageSearchJapaneseSummaryTest.java
@@ -1,0 +1,219 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.journal.search.test;
+
+import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
+import com.liferay.journal.model.JournalArticle;
+import com.liferay.journal.service.JournalArticleLocalService;
+import com.liferay.journal.test.util.search.JournalArticleBlueprint;
+import com.liferay.journal.test.util.search.JournalArticleContent;
+import com.liferay.journal.test.util.search.JournalArticleSearchFixture;
+import com.liferay.journal.test.util.search.JournalArticleTitle;
+import com.liferay.petra.string.StringBundler;
+import com.liferay.petra.string.StringPool;
+import com.liferay.portal.kernel.model.Group;
+import com.liferay.portal.kernel.model.User;
+import com.liferay.portal.kernel.search.Document;
+import com.liferay.portal.kernel.search.Field;
+import com.liferay.portal.kernel.search.Indexer;
+import com.liferay.portal.kernel.search.IndexerRegistry;
+import com.liferay.portal.kernel.search.highlight.HighlightUtil;
+import com.liferay.portal.kernel.test.rule.AggregateTestRule;
+import com.liferay.portal.kernel.test.rule.DeleteAfterTestRun;
+import com.liferay.portal.kernel.test.util.RandomTestUtil;
+import com.liferay.portal.kernel.test.util.TestPropsValues;
+import com.liferay.portal.kernel.util.LocaleUtil;
+import com.liferay.portal.search.test.util.SummaryFixture;
+import com.liferay.portal.service.test.ServiceTestUtil;
+import com.liferay.portal.test.rule.Inject;
+import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
+import com.liferay.users.admin.test.util.search.UserSearchFixture;
+
+import java.util.List;
+import java.util.Locale;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+/**
+ * @author Vagner B.C
+ */
+@RunWith(Arquillian.class)
+public class JournalArticleMultiLanguageSearchJapaneseSummaryTest {
+
+	@ClassRule
+	@Rule
+	public static final AggregateTestRule aggregateTestRule =
+		new LiferayIntegrationTestRule();
+
+	@Before
+	public void setUp() throws Exception {
+		ServiceTestUtil.setUser(TestPropsValues.getUser());
+
+		_indexer = indexerRegistry.getIndexer(JournalArticle.class);
+
+		_journalArticleSearchFixture = new JournalArticleSearchFixture(
+			journalArticleLocalService);
+
+		_journalArticleSearchFixture.setUp();
+
+		_journalArticles = _journalArticleSearchFixture.getJournalArticles();
+
+		_userSearchFixture = new UserSearchFixture();
+
+		_userSearchFixture.setUp();
+
+		_groups = _userSearchFixture.getGroups();
+		_users = _userSearchFixture.getUsers();
+
+		_group = _userSearchFixture.addGroup();
+
+		_user = _userSearchFixture.addUser(
+			RandomTestUtil.randomString(), _group);
+
+		_summaryFixture = new SummaryFixture<>(
+			JournalArticle.class, _group, null, _user);
+	}
+
+	@After
+	public void tearDown() {
+		_journalArticleSearchFixture.tearDown();
+
+		_userSearchFixture.tearDown();
+	}
+
+	@Test
+	public void testJapaneseSummaryHighlightedTermWithoutWordBoundaries()
+		throws Exception {
+
+		String highlightedContent = StringBundler.concat(
+			HighlightUtil.HIGHLIGHT_TAG_OPEN, "新規",
+			HighlightUtil.HIGHLIGHT_TAG_CLOSE, "作成");
+		String highlightedTitle = StringBundler.concat(
+			HighlightUtil.HIGHLIGHT_TAG_OPEN, "新規",
+			HighlightUtil.HIGHLIGHT_TAG_CLOSE, "作成");
+
+		testLocaleSummaryHighlighted(
+			LocaleUtil.JAPAN, "新規作成", "新規作成", highlightedTitle,
+			highlightedContent);
+	}
+
+	@Test
+	public void testJapaneseSummaryHighlightedTermWithWordBoundaries()
+		throws Exception {
+
+		String highlightedContent = StringBundler.concat(
+			"新規", HighlightUtil.HIGHLIGHT_TAG_OPEN, "作成",
+			HighlightUtil.HIGHLIGHT_TAG_CLOSE);
+		String highlightedTitle = StringBundler.concat(
+			"新規", HighlightUtil.HIGHLIGHT_TAG_OPEN, "作成",
+			HighlightUtil.HIGHLIGHT_TAG_CLOSE);
+
+		testLocaleSummaryHighlighted(
+			LocaleUtil.JAPAN, "新規作成", "新規作成", highlightedTitle,
+			highlightedContent);
+	}
+
+	protected JournalArticle addArticle(
+		String title, String content, Locale locale) {
+
+		return _journalArticleSearchFixture.addArticle(
+			new JournalArticleBlueprint() {
+				{
+					setGroupId(_group.getGroupId());
+					setJournalArticleContent(
+						new JournalArticleContent() {
+							{
+								put(locale, content);
+
+								setDefaultLocale(locale);
+								setName("content");
+							}
+						});
+					setJournalArticleTitle(
+						new JournalArticleTitle() {
+							{
+								put(locale, title);
+							}
+						});
+				}
+			});
+	}
+
+	protected Document getDocument(String title, String content, Locale locale)
+		throws Exception {
+
+		return _indexer.getDocument(addArticle(title, content, locale));
+	}
+
+	protected String getSnippetFieldName(String field, Locale locale) {
+		return StringBundler.concat(
+			Field.SNIPPET, StringPool.UNDERLINE, field, StringPool.UNDERLINE,
+			LocaleUtil.toLanguageId(locale));
+	}
+
+	protected void setSnippets(
+		String highlightedTitle, String highlightedContent, Document document,
+		Locale locale) {
+
+		document.addText(
+			getSnippetFieldName(Field.CONTENT, locale), highlightedContent);
+		document.addText(
+			getSnippetFieldName(Field.TITLE, locale), highlightedTitle);
+	}
+
+	protected void testLocaleSummaryHighlighted(
+			Locale locale, String title, String content,
+			String highlightedTitle, String highlightedContent)
+		throws Exception {
+
+		Document document = getDocument(title, content, locale);
+
+		setSnippets(highlightedTitle, highlightedContent, document, locale);
+
+		_summaryFixture.assertSummary(
+			highlightedTitle, highlightedContent, document);
+	}
+
+	@Inject
+	protected IndexerRegistry indexerRegistry;
+
+	@Inject
+	protected JournalArticleLocalService journalArticleLocalService;
+
+	private Group _group;
+
+	@DeleteAfterTestRun
+	private List<Group> _groups;
+
+	private Indexer<JournalArticle> _indexer;
+
+	@DeleteAfterTestRun
+	private List<JournalArticle> _journalArticles;
+
+	private JournalArticleSearchFixture _journalArticleSearchFixture;
+	private SummaryFixture<JournalArticle> _summaryFixture;
+	private User _user;
+
+	@DeleteAfterTestRun
+	private List<User> _users;
+
+	private UserSearchFixture _userSearchFixture;
+
+}

--- a/modules/apps/layout/layout-impl/src/main/java/com/liferay/layout/internal/search/LayoutIndexer.java
+++ b/modules/apps/layout/layout-impl/src/main/java/com/liferay/layout/internal/search/LayoutIndexer.java
@@ -35,7 +35,6 @@ import com.liferay.portal.kernel.search.SearchContext;
 import com.liferay.portal.kernel.search.Summary;
 import com.liferay.portal.kernel.search.filter.BooleanFilter;
 import com.liferay.portal.kernel.search.filter.TermsFilter;
-import com.liferay.portal.kernel.search.highlight.HighlightUtil;
 import com.liferay.portal.kernel.security.permission.ActionKeys;
 import com.liferay.portal.kernel.security.permission.PermissionChecker;
 import com.liferay.portal.kernel.service.LayoutLocalService;
@@ -51,6 +50,7 @@ import com.liferay.portal.kernel.util.Portal;
 import com.liferay.portal.kernel.util.StringUtil;
 import com.liferay.portal.kernel.util.Validator;
 import com.liferay.portal.search.batch.BatchIndexingHelper;
+import com.liferay.portal.search.highlight.HighlightHelper;
 
 import java.util.HashMap;
 import java.util.HashSet;
@@ -223,12 +223,12 @@ public class LayoutIndexer extends BaseIndexer<Layout> {
 
 		Set<String> highlights = new HashSet<>();
 
-		HighlightUtil.addSnippet(document, highlights, snippet, "temp");
+		_highlightHelper.addSnippet(document, highlights, snippet, "temp");
 
-		content = HighlightUtil.highlight(
+		content = _highlightHelper.highlight(
 			content, ArrayUtil.toStringArray(highlights),
-			HighlightUtil.HIGHLIGHT_TAG_OPEN,
-			HighlightUtil.HIGHLIGHT_TAG_CLOSE);
+			HighlightHelper.HIGHLIGHT_TAG_OPEN,
+			HighlightHelper.HIGHLIGHT_TAG_CLOSE, locale);
 
 		Summary summary = new Summary(locale, name, content);
 
@@ -291,12 +291,13 @@ public class LayoutIndexer extends BaseIndexer<Layout> {
 	};
 
 	private static final String[] _HIGHLIGHT_TAGS = {
-		HighlightUtil.HIGHLIGHT_TAG_OPEN, HighlightUtil.HIGHLIGHT_TAG_CLOSE
+		HighlightHelper.HIGHLIGHT_TAG_OPEN, HighlightHelper.HIGHLIGHT_TAG_CLOSE
 	};
 
 	private static final Log _log = LogFactoryUtil.getLog(LayoutIndexer.class);
 
 	private BatchIndexingHelper _batchIndexingHelper;
+	private HighlightHelper _highlightHelper;
 	private IndexWriterHelper _indexWriterHelper;
 	private LayoutLocalService _layoutLocalService;
 	private LayoutPageTemplateStructureLocalService

--- a/modules/apps/layout/layout-impl/src/main/java/com/liferay/layout/internal/search/spi/model/result/contributor/LayoutModelSummaryContributor.java
+++ b/modules/apps/layout/layout-impl/src/main/java/com/liferay/layout/internal/search/spi/model/result/contributor/LayoutModelSummaryContributor.java
@@ -18,12 +18,12 @@ import com.liferay.petra.string.StringPool;
 import com.liferay.portal.kernel.search.Document;
 import com.liferay.portal.kernel.search.Field;
 import com.liferay.portal.kernel.search.Summary;
-import com.liferay.portal.kernel.search.highlight.HighlightUtil;
 import com.liferay.portal.kernel.util.ArrayUtil;
 import com.liferay.portal.kernel.util.Html;
 import com.liferay.portal.kernel.util.LocaleUtil;
 import com.liferay.portal.kernel.util.StringUtil;
 import com.liferay.portal.kernel.util.Validator;
+import com.liferay.portal.search.highlight.HighlightHelper;
 import com.liferay.portal.search.spi.model.result.contributor.ModelSummaryContributor;
 
 import java.util.HashSet;
@@ -73,12 +73,12 @@ public class LayoutModelSummaryContributor implements ModelSummaryContributor {
 
 		Set<String> highlights = new HashSet<>();
 
-		HighlightUtil.addSnippet(document, highlights, snippet, "temp");
+		_highlightHelper.addSnippet(document, highlights, snippet, "temp");
 
-		content = HighlightUtil.highlight(
+		content = _highlightHelper.highlight(
 			content, ArrayUtil.toStringArray(highlights),
-			HighlightUtil.HIGHLIGHT_TAG_OPEN,
-			HighlightUtil.HIGHLIGHT_TAG_CLOSE);
+			HighlightHelper.HIGHLIGHT_TAG_OPEN,
+			HighlightHelper.HIGHLIGHT_TAG_CLOSE, locale);
 
 		Summary summary = new Summary(locale, name, content);
 
@@ -92,8 +92,11 @@ public class LayoutModelSummaryContributor implements ModelSummaryContributor {
 	};
 
 	private static final String[] _HIGHLIGHT_TAGS = {
-		HighlightUtil.HIGHLIGHT_TAG_OPEN, HighlightUtil.HIGHLIGHT_TAG_CLOSE
+		HighlightHelper.HIGHLIGHT_TAG_OPEN, HighlightHelper.HIGHLIGHT_TAG_CLOSE
 	};
+
+	@Reference
+	private HighlightHelper _highlightHelper;
 
 	@Reference
 	private Html _html;

--- a/modules/apps/portal-search/portal-search-api/src/main/java/com/liferay/portal/search/highlight/HighlightHelper.java
+++ b/modules/apps/portal-search/portal-search-api/src/main/java/com/liferay/portal/search/highlight/HighlightHelper.java
@@ -1,0 +1,48 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.portal.search.highlight;
+
+import aQute.bnd.annotation.ProviderType;
+
+import com.liferay.portal.kernel.search.Document;
+
+import java.util.Locale;
+import java.util.Set;
+
+/**
+ * @author Vagner B.C
+ */
+@ProviderType
+public interface HighlightHelper {
+
+	public static final String HIGHLIGHT_TAG_CLOSE = "</liferay-hl>";
+
+	public static final String HIGHLIGHT_TAG_OPEN = "<liferay-hl>";
+
+	public static final String[] HIGHLIGHTS = {
+		"<span class=\"highlight\">", "</span>"
+	};
+
+	public void addSnippet(
+		Document document, Set<String> queryTerms, String snippet,
+		String snippetFieldName);
+
+	public String highlight(String s, String[] queryTerms);
+
+	public String highlight(
+		String s, String[] queryTerms, String highlight1, String highlight2,
+		Locale locale);
+
+}

--- a/modules/apps/portal-search/portal-search/src/main/java/com/liferay/portal/search/internal/highlight/HighlightHelperImpl.java
+++ b/modules/apps/portal-search/portal-search/src/main/java/com/liferay/portal/search/internal/highlight/HighlightHelperImpl.java
@@ -1,0 +1,132 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.portal.search.internal.highlight;
+
+import com.liferay.petra.string.StringPool;
+import com.liferay.portal.kernel.search.Document;
+import com.liferay.portal.kernel.search.Field;
+import com.liferay.portal.kernel.util.ArrayUtil;
+import com.liferay.portal.kernel.util.LocaleUtil;
+import com.liferay.portal.kernel.util.StringBundler;
+import com.liferay.portal.kernel.util.StringUtil;
+import com.liferay.portal.kernel.util.Validator;
+import com.liferay.portal.search.highlight.HighlightHelper;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.Locale;
+import java.util.Set;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import org.osgi.service.component.annotations.Component;
+
+/**
+ * @author Vagner B.C
+ */
+@Component(service = HighlightHelper.class)
+public class HighlightHelperImpl implements HighlightHelper {
+
+	public static final List<Locale> nonBoundaryLocales = Arrays.asList(
+		LocaleUtil.JAPAN, LocaleUtil.JAPANESE, LocaleUtil.CHINA,
+		LocaleUtil.CHINESE, LocaleUtil.SIMPLIFIED_CHINESE,
+		LocaleUtil.TRADITIONAL_CHINESE);
+
+	public void addSnippet(
+		Document document, Set<String> queryTerms, String snippet,
+		String snippetFieldName) {
+
+		if (!snippet.equals(StringPool.BLANK)) {
+			Matcher matcher = _pattern.matcher(snippet);
+
+			while (matcher.find()) {
+				queryTerms.add(matcher.group(1));
+			}
+
+			snippet = StringUtil.replace(
+				snippet, HIGHLIGHT_TAG_OPEN, StringPool.BLANK);
+			snippet = StringUtil.replace(
+				snippet, HIGHLIGHT_TAG_CLOSE, StringPool.BLANK);
+		}
+
+		document.addText(
+			Field.SNIPPET.concat(
+				StringPool.UNDERLINE
+			).concat(
+				snippetFieldName
+			),
+			snippet);
+	}
+
+	public String highlight(String s, String[] queryTerms) {
+		return highlight(s, queryTerms, HIGHLIGHTS[0], HIGHLIGHTS[1], null);
+	}
+
+	public String highlight(
+		String s, String[] queryTerms, String highlight1, String highlight2,
+		Locale locale) {
+
+		if (Validator.isBlank(s) || ArrayUtil.isEmpty(queryTerms)) {
+			return s;
+		}
+
+		StringBundler sb = new StringBundler(3 * queryTerms.length - 1);
+
+		for (int i = 0; i < queryTerms.length; i++) {
+			if (i != 0) {
+				sb.append(StringPool.PIPE);
+			}
+
+			sb.append(Pattern.quote(queryTerms[i].trim()));
+
+			if ((locale == null) || !nonBoundaryLocales.contains(locale)) {
+				sb.append(_REGEXP_WORD_BOUNDARY);
+			}
+		}
+
+		Pattern pattern = Pattern.compile(
+			sb.toString(), Pattern.CASE_INSENSITIVE | Pattern.UNICODE_CASE);
+
+		return _highlight(s, pattern, highlight1, highlight2);
+	}
+
+	private static String _highlight(
+		String s, Pattern pattern, String highlight1, String highlight2) {
+
+		Matcher matcher = pattern.matcher(s);
+
+		if (!matcher.find()) {
+			return s;
+		}
+
+		StringBuffer sb = new StringBuffer();
+
+		do {
+			matcher.appendReplacement(
+				sb, highlight1 + matcher.group() + highlight2);
+		}
+		while (matcher.find());
+
+		matcher.appendTail(sb);
+
+		return sb.toString();
+	}
+
+	private static final String _REGEXP_WORD_BOUNDARY = "\\b";
+
+	private static final Pattern _pattern = Pattern.compile(
+		HIGHLIGHT_TAG_OPEN + "(.*?)" + HIGHLIGHT_TAG_CLOSE);
+
+}


### PR DESCRIPTION
https://issues.liferay.com/browse/LPS-84701

Content used: **新規作成**
Highlight used: **新規**
com.liferay.portal.kernel.search.highlight.HighlightUtil linha: 88
Regex that was created in the method highlight to get the highlight term used: **\Q新規\E\b**
The problem is that Japanese is written / read from right to left and has no space character.

The "\b" of the regex causes the word **"新規"** to not be found
The possible solution is to add a locale parameter in the HighlightUtil.highlight () method and check if the language code is Japan or another that has the same respects (Chinese, etc.) to not add the bondary in the regex.

**Solution 1** : https://github.com/brandizzi/liferay-portal/pull/714