### PR TITLE
LPS-90953 Tests to check for indexing problems during portal startup

### DIFF
--- a/modules/apps/company/company-test/build.gradle
+++ b/modules/apps/company/company-test/build.gradle
@@ -1,6 +1,11 @@
 dependencies {
 	testIntegrationCompile group: "com.liferay.portal", name: "com.liferay.portal.impl", version: "default"
 	testIntegrationCompile group: "com.liferay.portal", name: "com.liferay.portal.kernel", version: "default"
+	testIntegrationCompile group: "org.osgi", name: "org.osgi.service.component", version: "1.3.0"
+	testIntegrationCompile project(":apps:dynamic-data-mapping:dynamic-data-mapping-api")
+	testIntegrationCompile project(":apps:portal-search:portal-search-api")
+	testIntegrationCompile project(":apps:portal-search:portal-search-spi")
+	testIntegrationCompile project(":apps:users-admin:users-admin-test-util")
 	testIntegrationCompile project(":core:petra:petra-reflect")
 	testIntegrationCompile project(":test:arquillian-extension-junit-bridge")
 }

--- a/modules/apps/company/company-test/src/testIntegration/java/com/liferay/company/search/test/DefaultDDLStructuresPortalInstanceTest.java
+++ b/modules/apps/company/company-test/src/testIntegration/java/com/liferay/company/search/test/DefaultDDLStructuresPortalInstanceTest.java
@@ -1,0 +1,4 @@
+package com.liferay.company.search.test;
+
+public class DefaultDDLStructuresPortalInstanceTest {
+}

--- a/modules/apps/company/company-test/src/testIntegration/java/com/liferay/company/search/test/DefaultDDLStructuresPortalInstanceTest.java
+++ b/modules/apps/company/company-test/src/testIntegration/java/com/liferay/company/search/test/DefaultDDLStructuresPortalInstanceTest.java
@@ -1,4 +1,312 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
 package com.liferay.company.search.test;
 
+import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
+import com.liferay.dynamic.data.mapping.model.DDMStructure;
+import com.liferay.dynamic.data.mapping.service.DDMStructureLocalService;
+import com.liferay.petra.string.StringPool;
+import com.liferay.portal.kernel.model.Company;
+import com.liferay.portal.kernel.model.Group;
+import com.liferay.portal.kernel.model.User;
+import com.liferay.portal.kernel.search.Document;
+import com.liferay.portal.kernel.search.Field;
+import com.liferay.portal.kernel.search.Hits;
+import com.liferay.portal.kernel.search.Indexer;
+import com.liferay.portal.kernel.search.IndexerRegistryUtil;
+import com.liferay.portal.kernel.search.QueryConfig;
+import com.liferay.portal.kernel.search.SearchContext;
+import com.liferay.portal.kernel.security.permission.PermissionThreadLocal;
+import com.liferay.portal.kernel.service.CompanyLocalServiceUtil;
+import com.liferay.portal.kernel.test.rule.AggregateTestRule;
+import com.liferay.portal.kernel.test.util.RandomTestUtil;
+import com.liferay.portal.test.rule.Inject;
+import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
+import com.liferay.portal.test.rule.PermissionCheckerMethodTestRule;
+import com.liferay.portal.test.rule.SybaseDump;
+import com.liferay.portal.test.rule.SybaseDumpTransactionLog;
+import com.liferay.users.admin.test.util.search.DummyPermissionChecker;
+
+import java.util.Arrays;
+import java.util.Map;
+import java.util.Set;
+import java.util.function.Predicate;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import org.osgi.framework.Bundle;
+import org.osgi.framework.BundleContext;
+import org.osgi.framework.FrameworkUtil;
+import org.osgi.framework.ServiceReference;
+import org.osgi.service.component.runtime.ServiceComponentRuntime;
+import org.osgi.service.component.runtime.dto.ComponentDescriptionDTO;
+
+/**
+ * @author Vagner B.C
+ */
+@RunWith(Arquillian.class)
+@SybaseDumpTransactionLog(dumpBefore = {SybaseDump.CLASS, SybaseDump.METHOD})
 public class DefaultDDLStructuresPortalInstanceTest {
+
+	@ClassRule
+	@Rule
+	public static final AggregateTestRule aggregateTestRule =
+		new AggregateTestRule(
+			new LiferayIntegrationTestRule(),
+			PermissionCheckerMethodTestRule.INSTANCE);
+
+	@Before
+	public void setUp() {
+		_indexer = IndexerRegistryUtil.getIndexer(DDMStructure.class);
+
+		PermissionThreadLocal.setPermissionChecker(
+			new DummyPermissionChecker() {
+
+				@Override
+				public long getCompanyId() {
+					return _company.getCompanyId();
+				}
+
+				@Override
+				public boolean hasPermission(
+					Group group, String name, long primKey, String actionId) {
+
+					return true;
+				}
+
+				@Override
+				public boolean hasPermission(
+					Group group, String name, String primKey, String actionId) {
+
+					return true;
+				}
+
+				@Override
+				public boolean hasPermission(
+					long groupId, String name, long primKey, String actionId) {
+
+					return true;
+				}
+
+				@Override
+				public boolean hasPermission(
+					long groupId, String name, String primKey,
+					String actionId) {
+
+					return true;
+				}
+
+				@Override
+				public boolean isCompanyAdmin(long companyId) {
+					return true;
+				}
+
+			});
+	}
+
+	@After
+	public void tearDown() throws Exception {
+		CompanyLocalServiceUtil.deleteCompany(_company.getCompanyId());
+	}
+
+	@Test
+	public void testDefaultDDLStructuresPortalInstance() throws Exception {
+		_company = addCompany();
+
+		User user = _company.getDefaultUser();
+
+		SearchContext searchContext = new SearchContext();
+
+		searchContext.setCompanyId(_company.getCompanyId());
+		searchContext.setKeywords(user.getFullName());
+		searchContext.setUserId(user.getUserId());
+
+		QueryConfig queryConfig = searchContext.getQueryConfig();
+
+		queryConfig.setSelectedFieldNames(StringPool.STAR);
+
+		Hits hits = _indexer.search(searchContext);
+
+		Assert.assertEquals("Must have 9 documents", 9, hits.getLength());
+	}
+
+	@Test
+	public void testDefaultDDLStructuresPortalInstanceDDMStructureModelContributorProblem()
+		throws Exception {
+
+		_disableModelContributor();
+
+		_company = addCompany();
+
+		_enableModelContributor();
+
+		User user = _company.getDefaultUser();
+
+		SearchContext searchContext = new SearchContext();
+
+		searchContext.setCompanyId(_company.getCompanyId());
+		searchContext.setKeywords(user.getFullName());
+		searchContext.setUserId(user.getUserId());
+		searchContext.setAttribute(
+			"entryClassName", DDMStructure.class.getName());
+
+		QueryConfig queryConfig = searchContext.getQueryConfig();
+
+		queryConfig.setSelectedFieldNames(StringPool.STAR);
+
+		Hits hits = _indexer.search(searchContext);
+
+		_assertNoOneDDMStructureIndexed(hits);
+	}
+
+	@Test
+	public void testDefaultDDLStructuresPortalInstanceDefaultIndexerProblem()
+		throws Exception {
+
+		_unregisterIndexer();
+
+		_company = addCompany();
+
+		_registerIndexer();
+
+		User user = _company.getDefaultUser();
+
+		SearchContext searchContext = new SearchContext();
+
+		searchContext.setCompanyId(_company.getCompanyId());
+		searchContext.setKeywords(user.getFullName());
+		searchContext.setUserId(user.getUserId());
+		searchContext.setAttribute(
+			"entryClassName", DDMStructure.class.getName());
+
+		QueryConfig queryConfig = searchContext.getQueryConfig();
+
+		queryConfig.setSelectedFieldNames(StringPool.STAR);
+
+		Hits hits = _indexer.search(searchContext);
+
+		Assert.assertEquals("Must have 0 documents", 0, hits.getLength());
+	}
+
+	protected Company addCompany() throws Exception {
+		String webId = RandomTestUtil.randomString() + "test.com";
+
+		return CompanyLocalServiceUtil.addCompany(
+			webId, webId, "test.com", false, 0, true);
+	}
+
+	private static void _disableModelContributor() {
+		Bundle bundle = FrameworkUtil.getBundle(DDMStructureLocalService.class);
+
+		BundleContext bundleContext = bundle.getBundleContext();
+
+		ServiceReference<DDMStructureLocalService> serviceReference =
+			bundleContext.getServiceReference(DDMStructureLocalService.class);
+
+		bundle = serviceReference.getBundle();
+
+		_componentDescriptionDTO =
+			_serviceComponentRuntime.getComponentDescriptionDTO(
+				bundle,
+				"com.liferay.dynamic.data.mapping.internal.search.spi.model." +
+					"index.contributor.DDMStructureModelDocumentContributor");
+
+		_enabled = _serviceComponentRuntime.isComponentEnabled(
+			_componentDescriptionDTO);
+
+		if (_enabled) {
+			_serviceComponentRuntime.disableComponent(_componentDescriptionDTO);
+		}
+	}
+
+	private static void _enableModelContributor() {
+		if (_enabled) {
+			_serviceComponentRuntime.enableComponent(_componentDescriptionDTO);
+		}
+	}
+
+	private static void _registerIndexer() {
+		IndexerRegistryUtil.register(_indexer);
+	}
+
+	private static void _unregisterIndexer() {
+		IndexerRegistryUtil.unregister(_indexer);
+	}
+
+	private void _assertNoOneDDMStructureIndexed(Hits hits) {
+		Stream<Document> stream = Arrays.stream(hits.getDocs());
+
+		stream.forEach(
+			document -> {
+				Map<String, String> map = _getFieldValues(
+					document, name -> name.startsWith("entryClassName"));
+
+				map.forEach(
+					(key, value) -> Assert.assertFalse(
+						value.contains("DDMStructure")));
+			});
+	}
+
+	private Map<String, String> _getFieldValues(
+		Document document, Predicate<String> predicate) {
+
+		Map<String, Field> fieldsMap = document.getFields();
+
+		Set<Map.Entry<String, Field>> entrySet = fieldsMap.entrySet();
+
+		Stream<Map.Entry<String, Field>> stream = entrySet.stream();
+
+		if (predicate != null) {
+			stream = stream.filter(entry -> predicate.test(entry.getKey()));
+		}
+
+		return stream.collect(
+			Collectors.toMap(
+				Map.Entry::getKey,
+				entry -> {
+					Field field = entry.getValue();
+
+					String[] values = field.getValues();
+
+					if (values == null) {
+						return null;
+					}
+
+					if (values.length == 1) {
+						return values[0];
+					}
+
+					return String.valueOf(Arrays.asList(values));
+				}));
+	}
+
+	private static ComponentDescriptionDTO _componentDescriptionDTO;
+	private static boolean _enabled;
+	private static Indexer<DDMStructure> _indexer;
+
+	@Inject
+	private static ServiceComponentRuntime _serviceComponentRuntime;
+
+	private Company _company;
+
 }

--- a/modules/apps/dynamic-data-lists/dynamic-data-lists-test/build.gradle
+++ b/modules/apps/dynamic-data-lists/dynamic-data-lists-test/build.gradle
@@ -12,8 +12,10 @@ dependencies {
 	testIntegrationCompile group: "org.apache.poi", name: "poi", version: "3.15"
 	testIntegrationCompile project(":apps:dynamic-data-mapping:dynamic-data-mapping-test-util")
 	testIntegrationCompile project(":apps:export-import:export-import-test-util")
+	testIntegrationCompile project(":apps:portal-search:portal-search-test-util")
 	testIntegrationCompile project(":apps:portal:portal-upgrade-api")
 	testIntegrationCompile project(":apps:ratings:ratings-test-util")
+	testIntegrationCompile project(":apps:users-admin:users-admin-test-util")
 	testIntegrationCompile project(":core:petra:petra-string")
 	testIntegrationCompile project(":core:registry-api")
 	testIntegrationCompile project(":test:arquillian-extension-junit-bridge")

--- a/modules/apps/dynamic-data-lists/dynamic-data-lists-test/src/testIntegration/java/com/liferay/dynamic/data/lists/search/test/DefaultDDLStructuresPortalInstanceLifecycleListenerSearchTest.java
+++ b/modules/apps/dynamic-data-lists/dynamic-data-lists-test/src/testIntegration/java/com/liferay/dynamic/data/lists/search/test/DefaultDDLStructuresPortalInstanceLifecycleListenerSearchTest.java
@@ -1,0 +1,132 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.dynamic.data.lists.search.test;
+
+import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
+import com.liferay.dynamic.data.lists.model.DDLRecordSet;
+import com.liferay.dynamic.data.mapping.model.DDMStructure;
+import com.liferay.dynamic.data.mapping.util.DefaultDDMStructureHelper;
+import com.liferay.portal.kernel.model.Group;
+import com.liferay.portal.kernel.model.User;
+import com.liferay.portal.kernel.search.Document;
+import com.liferay.portal.kernel.service.ServiceContext;
+import com.liferay.portal.kernel.test.rule.AggregateTestRule;
+import com.liferay.portal.kernel.test.rule.DeleteAfterTestRun;
+import com.liferay.portal.kernel.test.util.RandomTestUtil;
+import com.liferay.portal.kernel.util.LocaleUtil;
+import com.liferay.portal.kernel.util.Portal;
+import com.liferay.portal.search.test.util.IndexerFixture;
+import com.liferay.portal.test.rule.Inject;
+import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
+import com.liferay.portal.test.rule.PermissionCheckerMethodTestRule;
+import com.liferay.users.admin.test.util.search.UserSearchFixture;
+
+import java.util.List;
+
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+/**
+ * @author Vagner B.C
+ */
+@RunWith(Arquillian.class)
+public class DefaultDDLStructuresPortalInstanceLifecycleListenerSearchTest {
+
+	@ClassRule
+	@Rule
+	public static final AggregateTestRule aggregateTestRule =
+		new AggregateTestRule(
+			new LiferayIntegrationTestRule(),
+			PermissionCheckerMethodTestRule.INSTANCE);
+
+	@Before
+	public void setUp() throws Exception {
+		setUpUserSearchFixture();
+
+		setUpDDMStructureIndexerFixture();
+	}
+
+	@After
+	public void tearDown() {
+		ddmStructureIndexerFixture.deleteDocuments(_documents);
+	}
+
+	@Test
+	public void testIndexedDefaultDDLStructures() throws Exception {
+		ServiceContext serviceContext = new ServiceContext();
+
+		serviceContext.setAddGuestPermissions(true);
+		serviceContext.setAddGroupPermissions(true);
+		serviceContext.setScopeGroupId(group.getGroupId());
+		serviceContext.setUserId(user.getUserId());
+
+		_defaultDDMStructureHelper.addDDMStructures(
+			user.getUserId(), group.getGroupId(),
+			_portal.getClassNameId(DDLRecordSet.class),
+			DefaultDDLStructuresPortalInstanceLifecycleListenerSearchTest.class.
+				getClassLoader(),
+			"com/liferay/dynamic/data/lists/search" +
+				"/default-dynamic-data-lists-structures.xml",
+			serviceContext);
+
+		_documents = ddmStructureIndexerFixture.search(
+			user.getUserId(), user.getFullName(), LocaleUtil.US);
+
+		Assert.assertEquals("Must have 6 documents", 6, _documents.length);
+	}
+
+	protected void setUpDDMStructureIndexerFixture() {
+		ddmStructureIndexerFixture = new IndexerFixture<>(DDMStructure.class);
+	}
+
+	protected void setUpUserSearchFixture() throws Exception {
+		userSearchFixture = new UserSearchFixture();
+
+		userSearchFixture.setUp();
+
+		_groups = userSearchFixture.getGroups();
+
+		_users = userSearchFixture.getUsers();
+
+		group = userSearchFixture.addGroup();
+
+		user = userSearchFixture.addUser(RandomTestUtil.randomString(), group);
+	}
+
+	protected IndexerFixture<DDMStructure> ddmStructureIndexerFixture;
+	protected Group group;
+	protected User user;
+	protected UserSearchFixture userSearchFixture;
+
+	@Inject
+	private DefaultDDMStructureHelper _defaultDDMStructureHelper;
+
+	private Document[] _documents;
+
+	@DeleteAfterTestRun
+	private List<Group> _groups;
+
+	@Inject
+	private Portal _portal;
+
+	@DeleteAfterTestRun
+	private List<User> _users;
+
+}

--- a/modules/apps/dynamic-data-lists/dynamic-data-lists-test/src/testIntegration/resources/com/liferay/dynamic/data/lists/search/default-dynamic-data-lists-structures.xml
+++ b/modules/apps/dynamic-data-lists/dynamic-data-lists-test/src/testIntegration/resources/com/liferay/dynamic/data/lists/search/default-dynamic-data-lists-structures.xml
@@ -1,0 +1,430 @@
+<?xml version="1.0"?>
+
+<root>
+	<structure>
+		<name><![CDATA[Contacts]]></name>
+		<description><![CDATA[Contacts]]></description>
+		<root available-locales="[$LOCALE_DEFAULT$]" default-locale="[$LOCALE_DEFAULT$]">
+			<dynamic-element dataType="string" indexType="keyword" name="company" required="false" showLabel="true" type="text" width="medium">
+				<meta-data locale="[$LOCALE_DEFAULT$]">
+					<entry name="label"><![CDATA[Company]]></entry>
+					<entry name="predefinedValue"><![CDATA[]]></entry>
+				</meta-data>
+			</dynamic-element>
+			<dynamic-element dataType="string" indexType="keyword" name="email" required="false" showLabel="true" type="text" width="medium">
+				<meta-data locale="[$LOCALE_DEFAULT$]">
+					<entry name="label"><![CDATA[Email]]></entry>
+					<entry name="predefinedValue"><![CDATA[]]></entry>
+				</meta-data>
+			</dynamic-element>
+			<dynamic-element dataType="string" indexType="keyword" name="firstName" required="false" showLabel="true" type="text" width="medium">
+				<meta-data locale="[$LOCALE_DEFAULT$]">
+					<entry name="label"><![CDATA[First Name]]></entry>
+					<entry name="predefinedValue"><![CDATA[]]></entry>
+				</meta-data>
+			</dynamic-element>
+			<dynamic-element dataType="string" indexType="keyword" multiple="false" name="imService" required="false" showLabel="true" type="select">
+				<dynamic-element name="gtalk" type="option" value="gtalk">
+					<meta-data locale="[$LOCALE_DEFAULT$]">
+						<entry name="label"><![CDATA[GTalk]]></entry>
+					</meta-data>
+				</dynamic-element>
+				<meta-data locale="[$LOCALE_DEFAULT$]">
+					<entry name="label"><![CDATA[Instant Messenger Service]]></entry>
+					<entry name="predefinedValue"><![CDATA[["gtalk"]]]></entry>
+				</meta-data>
+			</dynamic-element>
+			<dynamic-element dataType="string" indexType="keyword" name="imUserName" required="false" showLabel="true" type="text" width="medium">
+				<meta-data locale="[$LOCALE_DEFAULT$]">
+					<entry name="label"><![CDATA[Instant Messenger]]></entry>
+					<entry name="predefinedValue"><![CDATA[]]></entry>
+				</meta-data>
+			</dynamic-element>
+			<dynamic-element dataType="string" indexType="keyword" name="jobTitle" required="false" showLabel="true" type="text" width="medium">
+				<meta-data locale="[$LOCALE_DEFAULT$]">
+					<entry name="label"><![CDATA[Job Title]]></entry>
+					<entry name="predefinedValue"><![CDATA[]]></entry>
+				</meta-data>
+			</dynamic-element>
+			<dynamic-element dataType="string" indexType="keyword" name="lastName" required="false" showLabel="true" type="text" width="medium">
+				<meta-data locale="[$LOCALE_DEFAULT$]">
+					<entry name="label"><![CDATA[Last Name]]></entry>
+					<entry name="predefinedValue"><![CDATA[]]></entry>
+				</meta-data>
+			</dynamic-element>
+			<dynamic-element dataType="string" indexType="text" name="notes" required="false" showLabel="true" type="textarea" width="large">
+				<meta-data locale="[$LOCALE_DEFAULT$]">
+					<entry name="label"><![CDATA[Notes]]></entry>
+					<entry name="predefinedValue"><![CDATA[]]></entry>
+				</meta-data>
+			</dynamic-element>
+			<dynamic-element dataType="string" indexType="keyword" name="phoneMobile" required="false" showLabel="true" type="text" width="medium">
+				<meta-data locale="[$LOCALE_DEFAULT$]">
+					<entry name="label"><![CDATA[Phone (Mobile)]]></entry>
+					<entry name="predefinedValue"><![CDATA[]]></entry>
+				</meta-data>
+			</dynamic-element>
+			<dynamic-element dataType="string" indexType="keyword" name="phoneOffice" required="false" showLabel="true" type="text" width="medium">
+				<meta-data locale="[$LOCALE_DEFAULT$]">
+					<entry name="label"><![CDATA[Phone (Office)]]></entry>
+					<entry name="predefinedValue"><![CDATA[]]></entry>
+				</meta-data>
+			</dynamic-element>
+		</root>
+	</structure>
+	<structure>
+		<name><![CDATA[Events]]></name>
+		<description><![CDATA[Events]]></description>
+		<root available-locales="[$LOCALE_DEFAULT$]" default-locale="[$LOCALE_DEFAULT$]">
+			<dynamic-element dataType="document-library" fieldNamespace="ddm" indexType="keyword" name="attachment" required="false" showLabel="true" type="ddm-documentlibrary">
+				<meta-data locale="[$LOCALE_DEFAULT$]">
+					<entry name="label"><![CDATA[Attachment]]></entry>
+					<entry name="predefinedValue"><![CDATA[]]></entry>
+					<entry name="tip"><![CDATA[Upload documents no larger than 3,000k.]]></entry>
+				</meta-data>
+			</dynamic-element>
+			<dynamic-element dataType="double" fieldNamespace="ddm" indexType="keyword" name="cost" required="false" showLabel="true" type="ddm-number" width="small">
+				<meta-data locale="[$LOCALE_DEFAULT$]">
+					<entry name="label"><![CDATA[Cost]]></entry>
+					<entry name="predefinedValue"><![CDATA[]]></entry>
+					<entry name="tip"><![CDATA[]]></entry>
+				</meta-data>
+			</dynamic-element>
+			<dynamic-element dataType="string" indexType="text" name="description" required="false" showLabel="true" type="textarea" width="large">
+				<meta-data locale="[$LOCALE_DEFAULT$]">
+					<entry name="label"><![CDATA[Description]]></entry>
+					<entry name="predefinedValue"><![CDATA[]]></entry>
+					<entry name="tip"><![CDATA[]]></entry>
+				</meta-data>
+			</dynamic-element>
+			<dynamic-element dataType="date" fieldNamespace="ddm" indexType="keyword" name="eventDate" required="false" showLabel="true" type="ddm-date" width="small">
+				<meta-data locale="[$LOCALE_DEFAULT$]">
+					<entry name="label"><![CDATA[Date]]></entry>
+					<entry name="predefinedValue"><![CDATA[]]></entry>
+					<entry name="tip"><![CDATA[]]></entry>
+				</meta-data>
+			</dynamic-element>
+			<dynamic-element dataType="string" indexType="keyword" name="eventName" required="false" showLabel="true" type="text" width="medium">
+				<meta-data locale="[$LOCALE_DEFAULT$]">
+					<entry name="label"><![CDATA[Event Name]]></entry>
+					<entry name="predefinedValue"><![CDATA[]]></entry>
+					<entry name="tip"><![CDATA[]]></entry>
+				</meta-data>
+			</dynamic-element>
+			<dynamic-element dataType="string" indexType="keyword" name="eventTime" required="false" showLabel="true" type="text" width="small">
+				<meta-data locale="[$LOCALE_DEFAULT$]">
+					<entry name="label"><![CDATA[Time]]></entry>
+					<entry name="predefinedValue"><![CDATA[]]></entry>
+					<entry name="tip"><![CDATA[]]></entry>
+				</meta-data>
+			</dynamic-element>
+			<dynamic-element dataType="string" indexType="keyword" name="location" required="false" showLabel="true" type="text" width="medium">
+				<meta-data locale="[$LOCALE_DEFAULT$]">
+					<entry name="label"><![CDATA[Location]]></entry>
+					<entry name="predefinedValue"><![CDATA[]]></entry>
+					<entry name="tip"><![CDATA[]]></entry>
+				</meta-data>
+			</dynamic-element>
+		</root>
+	</structure>
+	<structure>
+		<name><![CDATA[Inventory]]></name>
+		<description><![CDATA[Inventory]]></description>
+		<root available-locales="[$LOCALE_DEFAULT$]" default-locale="[$LOCALE_DEFAULT$]">
+			<dynamic-element dataType="string" indexType="text" name="description" required="false" showLabel="true" type="textarea" width="large">
+				<meta-data locale="[$LOCALE_DEFAULT$]">
+					<entry name="label"><![CDATA[Description]]></entry>
+					<entry name="predefinedValue"><![CDATA[]]></entry>
+					<entry name="style"><![CDATA[]]></entry>
+					<entry name="tip"><![CDATA[]]></entry>
+				</meta-data>
+			</dynamic-element>
+			<dynamic-element dataType="string" indexType="keyword" name="item" required="false" showLabel="true" type="text" width="small">
+				<meta-data locale="[$LOCALE_DEFAULT$]">
+					<entry name="label"><![CDATA[Item]]></entry>
+					<entry name="predefinedValue"><![CDATA[]]></entry>
+					<entry name="style"><![CDATA[]]></entry>
+					<entry name="tip"><![CDATA[]]></entry>
+				</meta-data>
+			</dynamic-element>
+			<dynamic-element dataType="string" indexType="keyword" name="location" required="false" showLabel="true" type="text" width="small">
+				<meta-data locale="[$LOCALE_DEFAULT$]">
+					<entry name="label"><![CDATA[Location]]></entry>
+					<entry name="predefinedValue"><![CDATA[]]></entry>
+					<entry name="style"><![CDATA[]]></entry>
+					<entry name="tip"><![CDATA[]]></entry>
+				</meta-data>
+			</dynamic-element>
+			<dynamic-element dataType="date" fieldNamespace="ddm" indexType="keyword" name="purchaseDate" required="false" showLabel="true" type="ddm-date" width="small">
+				<meta-data locale="[$LOCALE_DEFAULT$]">
+					<entry name="label"><![CDATA[Purchase Date]]></entry>
+					<entry name="predefinedValue"><![CDATA[]]></entry>
+					<entry name="style"><![CDATA[]]></entry>
+					<entry name="tip"><![CDATA[]]></entry>
+				</meta-data>
+			</dynamic-element>
+			<dynamic-element dataType="double" fieldNamespace="ddm" indexType="keyword" name="purchasePrice" required="false" showLabel="true" type="ddm-number" width="small">
+				<meta-data locale="[$LOCALE_DEFAULT$]">
+					<entry name="label"><![CDATA[Purchase Price]]></entry>
+					<entry name="predefinedValue"><![CDATA[]]></entry>
+					<entry name="tip"><![CDATA[]]></entry>
+				</meta-data>
+			</dynamic-element>
+			<dynamic-element dataType="double" fieldNamespace="ddm" indexType="keyword" name="quantity" required="false" showLabel="true" type="ddm-number" width="small">
+				<meta-data locale="[$LOCALE_DEFAULT$]">
+					<entry name="label"><![CDATA[Quantity]]></entry>
+					<entry name="predefinedValue"><![CDATA[]]></entry>
+					<entry name="tip"><![CDATA[]]></entry>
+				</meta-data>
+			</dynamic-element>
+		</root>
+	</structure>
+	<structure>
+		<name><![CDATA[Issues Tracking]]></name>
+		<description><![CDATA[Issue Tracking]]></description>
+		<root available-locales="[$LOCALE_DEFAULT$]" default-locale="[$LOCALE_DEFAULT$]">
+			<dynamic-element dataType="string" indexType="keyword" name="assignedTo" required="false" showLabel="true" type="text" width="small">
+				<meta-data locale="[$LOCALE_DEFAULT$]">
+					<entry name="label"><![CDATA[Assigned To]]></entry>
+					<entry name="predefinedValue"><![CDATA[]]></entry>
+				</meta-data>
+			</dynamic-element>
+			<dynamic-element dataType="document-library" fieldNamespace="ddm" indexType="keyword" name="attachment" required="false" showLabel="true" type="ddm-documentlibrary">
+				<meta-data locale="[$LOCALE_DEFAULT$]">
+					<entry name="label"><![CDATA[Attachment]]></entry>
+					<entry name="predefinedValue"><![CDATA[]]></entry>
+					<entry name="tip"><![CDATA[Upload documents no larger than 3,000k.]]></entry>
+				</meta-data>
+			</dynamic-element>
+			<dynamic-element dataType="string" indexType="text" name="comments" required="false" showLabel="true" type="textarea" width="large">
+				<meta-data locale="[$LOCALE_DEFAULT$]">
+					<entry name="label"><![CDATA[Comments]]></entry>
+					<entry name="predefinedValue"><![CDATA[]]></entry>
+				</meta-data>
+			</dynamic-element>
+			<dynamic-element dataType="string" indexType="text" name="description" required="false" showLabel="true" type="textarea" width="large">
+				<meta-data locale="[$LOCALE_DEFAULT$]">
+					<entry name="label"><![CDATA[Description]]></entry>
+					<entry name="predefinedValue"><![CDATA[]]></entry>
+				</meta-data>
+			</dynamic-element>
+			<dynamic-element dataType="date" fieldNamespace="ddm" indexType="keyword" name="dueDate" required="false" showLabel="true" type="ddm-date">
+				<meta-data locale="[$LOCALE_DEFAULT$]">
+					<entry name="label"><![CDATA[Due Date]]></entry>
+					<entry name="predefinedValue"><![CDATA[]]></entry>
+				</meta-data>
+			</dynamic-element>
+			<dynamic-element dataType="string" indexType="keyword" name="issueId" required="false" showLabel="true" type="text" width="small">
+				<meta-data locale="[$LOCALE_DEFAULT$]">
+					<entry name="label"><![CDATA[Issue ID]]></entry>
+					<entry name="predefinedValue"><![CDATA[]]></entry>
+				</meta-data>
+			</dynamic-element>
+			<dynamic-element dataType="string" indexType="keyword" multiple="false" name="severity" required="false" showLabel="true" type="select">
+				<dynamic-element name="critical" type="option" value="critical">
+					<meta-data locale="[$LOCALE_DEFAULT$]">
+						<entry name="label"><![CDATA[Critical]]></entry>
+					</meta-data>
+				</dynamic-element>
+				<dynamic-element name="major" type="option" value="major">
+					<meta-data locale="[$LOCALE_DEFAULT$]">
+						<entry name="label"><![CDATA[Major]]></entry>
+					</meta-data>
+				</dynamic-element>
+				<dynamic-element name="minor" type="option" value="minor">
+					<meta-data locale="[$LOCALE_DEFAULT$]">
+						<entry name="label"><![CDATA[Minor]]></entry>
+					</meta-data>
+				</dynamic-element>
+				<dynamic-element name="trivial" type="option" value="trivial">
+					<meta-data locale="[$LOCALE_DEFAULT$]">
+						<entry name="label"><![CDATA[Trivial]]></entry>
+					</meta-data>
+				</dynamic-element>
+				<meta-data locale="[$LOCALE_DEFAULT$]">
+					<entry name="label"><![CDATA[Severity]]></entry>
+					<entry name="predefinedValue"><![CDATA[["minor"]]]></entry>
+				</meta-data>
+			</dynamic-element>
+			<dynamic-element dataType="string" indexType="keyword" multiple="false" name="status" required="false" showLabel="true" type="select">
+				<dynamic-element name="open" type="option" value="open">
+					<meta-data locale="[$LOCALE_DEFAULT$]">
+						<entry name="label"><![CDATA[Open]]></entry>
+					</meta-data>
+				</dynamic-element>
+				<dynamic-element name="pending" type="option" value="pending">
+					<meta-data locale="[$LOCALE_DEFAULT$]">
+						<entry name="label"><![CDATA[Pending]]></entry>
+					</meta-data>
+				</dynamic-element>
+				<dynamic-element name="completed" type="option" value="completed">
+					<meta-data locale="[$LOCALE_DEFAULT$]">
+						<entry name="label"><![CDATA[Completed]]></entry>
+					</meta-data>
+				</dynamic-element>
+				<meta-data locale="[$LOCALE_DEFAULT$]">
+					<entry name="label"><![CDATA[Status]]></entry>
+					<entry name="predefinedValue"><![CDATA[["open"]]]></entry>
+				</meta-data>
+			</dynamic-element>
+			<dynamic-element dataType="string" indexType="keyword" name="title" required="false" showLabel="true" type="text" width="large">
+				<meta-data locale="[$LOCALE_DEFAULT$]">
+					<entry name="label"><![CDATA[Title]]></entry>
+					<entry name="predefinedValue"><![CDATA[]]></entry>
+				</meta-data>
+			</dynamic-element>
+		</root>
+	</structure>
+	<structure>
+		<name><![CDATA[Meeting Minutes]]></name>
+		<description><![CDATA[Meeting Minutes]]></description>
+		<root available-locales="[$LOCALE_DEFAULT$]" default-locale="[$LOCALE_DEFAULT$]">
+			<dynamic-element dataType="document-library" fieldNamespace="ddm" indexType="keyword" name="attachment" required="false" showLabel="true" type="ddm-documentlibrary">
+				<meta-data locale="[$LOCALE_DEFAULT$]">
+					<entry name="label"><![CDATA[Attachment]]></entry>
+					<entry name="predefinedValue"><![CDATA[]]></entry>
+					<entry name="tip"><![CDATA[Upload documents no larger than 3,000k.]]></entry>
+				</meta-data>
+			</dynamic-element>
+			<dynamic-element dataType="string" indexType="keyword" name="author" required="false" showLabel="true" type="text">
+				<meta-data locale="[$LOCALE_DEFAULT$]">
+					<entry name="label"><![CDATA[Author]]></entry>
+					<entry name="predefinedValue"><![CDATA[]]></entry>
+				</meta-data>
+			</dynamic-element>
+			<dynamic-element dataType="string" indexType="text" name="description" required="false" showLabel="true" type="textarea" width="large">
+				<meta-data locale="[$LOCALE_DEFAULT$]">
+					<entry name="label"><![CDATA[Description]]></entry>
+					<entry name="predefinedValue"><![CDATA[]]></entry>
+				</meta-data>
+			</dynamic-element>
+			<dynamic-element dataType="string" indexType="keyword" name="duration" required="false" showLabel="true" type="text">
+				<meta-data locale="[$LOCALE_DEFAULT$]">
+					<entry name="label"><![CDATA[Meeting Duration]]></entry>
+					<entry name="predefinedValue"><![CDATA[]]></entry>
+				</meta-data>
+			</dynamic-element>
+			<dynamic-element dataType="date" fieldNamespace="ddm" indexType="keyword" name="meetingDate" required="false" showLabel="true" type="ddm-date">
+				<meta-data locale="[$LOCALE_DEFAULT$]">
+					<entry name="label"><![CDATA[Meeting Date]]></entry>
+					<entry name="predefinedValue"><![CDATA[]]></entry>
+				</meta-data>
+			</dynamic-element>
+			<dynamic-element dataType="string" indexType="text" name="minutes" required="false" showLabel="true" type="textarea" width="large">
+				<meta-data locale="[$LOCALE_DEFAULT$]">
+					<entry name="label"><![CDATA[Minutes]]></entry>
+					<entry name="predefinedValue"><![CDATA[]]></entry>
+				</meta-data>
+			</dynamic-element>
+			<dynamic-element dataType="string" indexType="keyword" name="title" required="false" showLabel="true" type="text" width="large">
+				<meta-data locale="[$LOCALE_DEFAULT$]">
+					<entry name="label"><![CDATA[Title]]></entry>
+					<entry name="predefinedValue"><![CDATA[]]></entry>
+				</meta-data>
+			</dynamic-element>
+		</root>
+	</structure>
+	<structure>
+		<name><![CDATA[To Do]]></name>
+		<description><![CDATA[To Do]]></description>
+		<root available-locales="[$LOCALE_DEFAULT$]" default-locale="[$LOCALE_DEFAULT$]">
+			<dynamic-element dataType="string" indexType="keyword" name="assignedTo" required="false" showLabel="true" type="text" width="medium">
+				<meta-data locale="[$LOCALE_DEFAULT$]">
+					<entry name="label"><![CDATA[Assigned To]]></entry>
+					<entry name="predefinedValue"><![CDATA[]]></entry>
+				</meta-data>
+			</dynamic-element>
+			<dynamic-element dataType="document-library" fieldNamespace="ddm" indexType="keyword" name="attachment" required="false" showLabel="true" type="ddm-documentlibrary">
+				<meta-data locale="[$LOCALE_DEFAULT$]">
+					<entry name="label"><![CDATA[Attachment]]></entry>
+					<entry name="predefinedValue"><![CDATA[]]></entry>
+					<entry name="tip"><![CDATA[Upload documents no larger than 3,000k.]]></entry>
+				</meta-data>
+			</dynamic-element>
+			<dynamic-element dataType="string" indexType="text" name="comments" required="false" showLabel="true" type="textarea" width="large">
+				<meta-data locale="[$LOCALE_DEFAULT$]">
+					<entry name="label"><![CDATA[Comments]]></entry>
+					<entry name="predefinedValue"><![CDATA[]]></entry>
+				</meta-data>
+			</dynamic-element>
+			<dynamic-element dataType="string" indexType="text" name="description" required="false" showLabel="true" type="textarea" width="large">
+				<meta-data locale="[$LOCALE_DEFAULT$]">
+					<entry name="label"><![CDATA[Description]]></entry>
+					<entry name="predefinedValue"><![CDATA[]]></entry>
+				</meta-data>
+			</dynamic-element>
+			<dynamic-element dataType="date" fieldNamespace="ddm" indexType="keyword" name="endDate" required="false" showLabel="true" type="ddm-date">
+				<meta-data locale="[$LOCALE_DEFAULT$]">
+					<entry name="label"><![CDATA[End Date]]></entry>
+					<entry name="predefinedValue"><![CDATA[]]></entry>
+				</meta-data>
+			</dynamic-element>
+			<dynamic-element dataType="integer" fieldNamespace="ddm" indexType="keyword" name="percentComplete" required="false" showLabel="true" type="ddm-integer" width="small">
+				<meta-data locale="[$LOCALE_DEFAULT$]">
+					<entry name="label"><![CDATA[% Complete]]></entry>
+					<entry name="predefinedValue"><![CDATA[0]]></entry>
+					<entry name="tip"><![CDATA[]]></entry>
+				</meta-data>
+			</dynamic-element>
+			<dynamic-element dataType="string" indexType="keyword" multiple="false" name="severity" required="false" showLabel="true" type="select">
+				<dynamic-element name="critical" type="option" value="critical">
+					<meta-data locale="[$LOCALE_DEFAULT$]">
+						<entry name="label"><![CDATA[Critical]]></entry>
+					</meta-data>
+				</dynamic-element>
+				<dynamic-element name="major" type="option" value="major">
+					<meta-data locale="[$LOCALE_DEFAULT$]">
+						<entry name="label"><![CDATA[Major]]></entry>
+					</meta-data>
+				</dynamic-element>
+				<dynamic-element name="minor" type="option" value="minor">
+					<meta-data locale="[$LOCALE_DEFAULT$]">
+						<entry name="label"><![CDATA[Minor]]></entry>
+					</meta-data>
+				</dynamic-element>
+				<dynamic-element name="trivial" type="option" value="trivial">
+					<meta-data locale="[$LOCALE_DEFAULT$]">
+						<entry name="label"><![CDATA[Trivial]]></entry>
+					</meta-data>
+				</dynamic-element>
+				<meta-data locale="[$LOCALE_DEFAULT$]">
+					<entry name="label"><![CDATA[Severity]]></entry>
+					<entry name="predefinedValue"><![CDATA[["minor"]]]></entry>
+				</meta-data>
+			</dynamic-element>
+			<dynamic-element dataType="date" fieldNamespace="ddm" indexType="keyword" name="startDate" required="false" showLabel="true" type="ddm-date">
+				<meta-data locale="[$LOCALE_DEFAULT$]">
+					<entry name="label"><![CDATA[Start Date]]></entry>
+					<entry name="predefinedValue"><![CDATA[]]></entry>
+				</meta-data>
+			</dynamic-element>
+			<dynamic-element dataType="string" indexType="keyword" multiple="false" name="status" required="false" showLabel="true" type="select">
+				<dynamic-element name="open" type="option" value="open">
+					<meta-data locale="[$LOCALE_DEFAULT$]">
+						<entry name="label"><![CDATA[Open]]></entry>
+					</meta-data>
+				</dynamic-element>
+				<dynamic-element name="pending" type="option" value="pending">
+					<meta-data locale="[$LOCALE_DEFAULT$]">
+						<entry name="label"><![CDATA[Pending]]></entry>
+					</meta-data>
+				</dynamic-element>
+				<dynamic-element name="completed" type="option" value="completed">
+					<meta-data locale="[$LOCALE_DEFAULT$]">
+						<entry name="label"><![CDATA[Completed]]></entry>
+					</meta-data>
+				</dynamic-element>
+				<meta-data locale="[$LOCALE_DEFAULT$]">
+					<entry name="label"><![CDATA[Status]]></entry>
+					<entry name="predefinedValue"><![CDATA[["open"]]]></entry>
+				</meta-data>
+			</dynamic-element>
+			<dynamic-element dataType="string" indexType="keyword" name="title" required="false" showLabel="true" type="text" width="medium">
+				<meta-data locale="[$LOCALE_DEFAULT$]">
+					<entry name="label"><![CDATA[Title]]></entry>
+					<entry name="predefinedValue"><![CDATA[]]></entry>
+				</meta-data>
+			</dynamic-element>
+		</root>
+	</structure>
+</root>

--- a/portal-impl/src/com/liferay/portal/service/impl/CompanyLocalServiceImpl.java
+++ b/portal-impl/src/com/liferay/portal/service/impl/CompanyLocalServiceImpl.java
@@ -353,6 +353,7 @@ public class CompanyLocalServiceImpl extends CompanyLocalServiceBaseImpl {
 				defaultUser.setCompanyId(companyId);
 				defaultUser.setDefaultUser(true);
 				defaultUser.setContactId(counterLocalService.increment());
+				defaultUser.setFirstName("default");
 				defaultUser.setPassword("password");
 				defaultUser.setScreenName(
 					String.valueOf(defaultUser.getUserId()));


### PR DESCRIPTION
https://issues.liferay.com/browse/LPS-90953

There are some listeners in the portal that extend BasePortalInstanceLifecycleListener. 

These listeners are responsible for doing something during the initialization of the portal.

Basically, the problem is that some listeners, including the AddDefaultDDLStructuresPortalInstanceLifecycleListener, are being installed before some important classes that build the DefaultIndexer with all associated contributors.

We need to do something for these listeners to just be installed after these important classes that build the DefaultIndexer.

Classes that must be installed before listeners:

1 - DDMStructureSearchRegistrar (EX: DDMStructure index)

2 - ModelSearchConfiguratorImpl

3 - ModelSearchConfiguratorServiceTrackerCustomizer (Class responsible for building and registering the DefaultIndexer)

4 - IndexerRegistryImpl (Registers indexers)

When listeners are initialized before these classes, the IndexableAdvice class does not find the indexer (DefaultIndexer) and does not reindex the record.

Sometimes it does not happen. Sometimes this happens to some listeners and not to others.

This log file shows the case that the default DLLs are not indexed
[liferay.2019-06-10(Não indexou DDL default).log](https://github.com/brandizzi/liferay-portal/files/3276841/liferay.2019-06-10.Nao.indexou.DDL.default.log)
