### PR TITLE
LPS-87047 portal-search-synonyms-web: Layout minor adjustment

### DIFF
--- a/modules/apps/portal-search/portal-search-synonyms-web/src/main/java/com/liferay/portal/search/synonyms/web/internal/display/context/SynonymSetsEntryDisplayContext.java
+++ b/modules/apps/portal-search/portal-search-synonyms-web/src/main/java/com/liferay/portal/search/synonyms/web/internal/display/context/SynonymSetsEntryDisplayContext.java
@@ -27,6 +27,10 @@ public class SynonymSetsEntryDisplayContext {
 		return _synonyms;
 	}
 
+	public String getSynonymsFormatted() {
+		return _synonyms.replace(",", ", ");
+	}
+
 	private final String _synonyms;
 
 }

--- a/modules/apps/portal-search/portal-search-synonyms-web/src/main/java/com/liferay/portal/search/synonyms/web/internal/display/context/SynonymSetsPortletDisplayContext.java
+++ b/modules/apps/portal-search/portal-search-synonyms-web/src/main/java/com/liferay/portal/search/synonyms/web/internal/display/context/SynonymSetsPortletDisplayContext.java
@@ -94,6 +94,21 @@ public class SynonymSetsPortletDisplayContext {
 							LanguageUtil.get(_httpServletRequest, "delete"));
 						dropdownItem.setQuickAction(true);
 					});
+
+				add(
+					dropdownItem -> {
+						dropdownItem.setHref(
+							_renderResponse.createRenderURL(),
+							"mvcRenderCommandName", "updateSynonymsEntryRender",
+							"redirect",
+							PortalUtil.getCurrentURL(_httpServletRequest),
+							"synonymSets",
+							synonymSetsEntryDisplayContext.getSynonyms());
+
+						dropdownItem.setLabel(
+							LanguageUtil.get(
+								_httpServletRequest, "edit"));
+					});
 			}
 		};
 	}

--- a/modules/apps/portal-search/portal-search-synonyms-web/src/main/resources/META-INF/resources/js/components/SynonymSetsForm.es.js
+++ b/modules/apps/portal-search/portal-search-synonyms-web/src/main/resources/META-INF/resources/js/components/SynonymSetsForm.es.js
@@ -20,11 +20,6 @@ class SynonymSetsForm extends Component {
 		window.history.back();
 	};
 
-	_handleSaveAsDraft = () => {
-
-		/* TODO: Call backend to save as draft synonym sets */
-	};
-
 	_handleSubmit = () => {
 		event.preventDefault();
 		const form = document.forms[this.props.formName];
@@ -74,14 +69,9 @@ class SynonymSetsForm extends Component {
 						<label>{Liferay.Language.get('synonyms')}</label>
 						<ClayMultiselect
 							onAction={this._handleUpdate}
+							onSubmit={this._handleSubmit}
 							value={synonyms}
 						/>
-
-						<div className="form-feedback-group">
-							<div className="form-text">
-								{Liferay.Language.get('add-an-alias-instruction')}
-							</div>
-						</div>
 
 						<div className="sheet-footer">
 							<ClayButton
@@ -91,10 +81,6 @@ class SynonymSetsForm extends Component {
 								displayStyle="primary"
 								label={Liferay.Language.get('publish')}
 								onClick={this._handleSubmit}
-							/>
-							<ClayButton
-								label={Liferay.Language.get('save-as-draft')}
-								onClick={this._handleSaveAsDraft}
 							/>
 							<ClayButton
 								label={Liferay.Language.get('cancel')}

--- a/modules/apps/portal-search/portal-search-synonyms-web/src/main/resources/META-INF/resources/js/components/shared/ClayMultiselect.es.js
+++ b/modules/apps/portal-search/portal-search-synonyms-web/src/main/resources/META-INF/resources/js/components/shared/ClayMultiselect.es.js
@@ -14,6 +14,7 @@ const createOption = label => ({
 class ClayMultiselect extends Component {
 	static propTypes = {
 		onAction: PropTypes.func,
+		onSubmit: PropTypes.func,
 		value: PropTypes.arrayOf(String)
 	};
 
@@ -35,14 +36,15 @@ class ClayMultiselect extends Component {
 
 		const {inputValue} = this.state;
 
-		if (!inputValue) {
-			return;
-		}
-
 		switch (event.key) {
 		case 'Enter':
 		case 'Tab':
 		case ',':
+			if (!inputValue && event.key == 'Enter') {
+				this.props.onSubmit();
+				return;
+			}
+
 			if (!value.map(item => item.value).includes(inputValue)) {
 				this.props.onAction([...value, createOption(inputValue)]);
 			}

--- a/modules/apps/portal-search/portal-search-synonyms-web/src/main/resources/META-INF/resources/js/components/shared/ClayMultiselect.es.js
+++ b/modules/apps/portal-search/portal-search-synonyms-web/src/main/resources/META-INF/resources/js/components/shared/ClayMultiselect.es.js
@@ -27,8 +27,10 @@ class ClayMultiselect extends Component {
 		this.props.onAction(value);
 	};
 
-	_handleInputChange = inputValue => {
-		this.setState({inputValue});
+	_handleInputChange = (inputValue, event) => {
+		if (event.action == "input-change") {
+			this.setState({inputValue});
+		}
 	};
 
 	_handleKeyDown = event => {

--- a/modules/apps/portal-search/portal-search-synonyms-web/src/main/resources/META-INF/resources/update_synonym_sets.jsp
+++ b/modules/apps/portal-search/portal-search-synonyms-web/src/main/resources/META-INF/resources/update_synonym_sets.jsp
@@ -20,6 +20,8 @@
 taglib uri="http://liferay.com/tld/frontend" prefix="liferay-frontend" %><%@
 taglib uri="http://liferay.com/tld/theme" prefix="liferay-theme" %>
 
+<%@ page import="com.liferay.portal.kernel.util.ParamUtil" %>
+
 <liferay-frontend:defineObjects />
 
 <liferay-theme:defineObjects />
@@ -30,7 +32,9 @@ taglib uri="http://liferay.com/tld/theme" prefix="liferay-theme" %>
 String synonymSetsRootElementId = renderResponse.getNamespace() + "-synonym-sets-root";
 String synonymSets = (String)request.getAttribute("synonymSets");
 
+String redirect = ParamUtil.getString(request, "redirect");
 portletDisplay.setShowBackIcon(true);
+portletDisplay.setURLBack(redirect);
 %>
 
 <portlet:actionURL name="updateSynonymsEntryAction" var="updateSynonymsEntryURL">

--- a/modules/apps/portal-search/portal-search-synonyms-web/src/main/resources/META-INF/resources/view_synonym_sets.jsp
+++ b/modules/apps/portal-search/portal-search-synonyms-web/src/main/resources/META-INF/resources/view_synonym_sets.jsp
@@ -33,22 +33,6 @@ page import="com.liferay.portal.search.synonyms.web.internal.display.context.Syn
 SynonymSetsPortletDisplayContext synonymSetsPortletDisplayContext = (SynonymSetsPortletDisplayContext)request.getAttribute(SynonymsPortletKeys.SYNONYM_SETS_DISPLAY_CONTEXT);
 %>
 
-<clay:management-toolbar
-	clearResultsURL="<%= synonymSetsPortletDisplayContext.getClearResultsURL() %>"
-	componentId="synonymSetsEntriesManagementToolbar"
-	creationMenu="<%= synonymSetsPortletDisplayContext.getCreationMenu() %>"
-	disabled="<%= synonymSetsPortletDisplayContext.isDisabledManagementBar() %>"
-	filterDropdownItems="<%= synonymSetsPortletDisplayContext.getFilterItemsDropdownItems() %>"
-	itemsTotal="<%= synonymSetsPortletDisplayContext.getTotalItems() %>"
-	searchActionURL="<%= synonymSetsPortletDisplayContext.getSearchActionURL() %>"
-	searchContainerId="synonymSetsEntries"
-	searchFormName="searchFm"
-	selectable="<%= true %>"
-	showCreationMenu="<%= synonymSetsPortletDisplayContext.isShowCreationMenu() %>"
-	sortingOrder="<%= synonymSetsPortletDisplayContext.getOrderByType() %>"
-	sortingURL="<%= synonymSetsPortletDisplayContext.getSortingURL() %>"
-/>
-
 <aui:form cssClass="container-fluid-1280" method="post" name="SynonymSetsEntriesFm">
 	<aui:input name="redirect" type="hidden" value="<%= currentURL %>" />
 
@@ -73,15 +57,9 @@ SynonymSetsPortletDisplayContext synonymSetsPortletDisplayContext = (SynonymSets
 			>
 				<h2 class="h5">
 					<aui:a href="<%= rowURL %>">
-						<%= synonymSetsEntry.getSynonyms() %>
+						<%= synonymSetsEntry.getSynonymsFormatted() %>
 					</aui:a>
 				</h2>
-
-				<span class="text-default">
-					<span class="label label-success text-uppercase">
-						<liferay-ui:message key="approved" />
-					</span>
-				</span>
 			</liferay-ui:search-container-column-text>
 
 			<liferay-ui:search-container-column-text>


### PR DESCRIPTION
Fixed:
* get rid of “Save as Draft” button, Approved status, etc
* action menu should include “Edit” along with “Delete”
* you can enter synonyms with commas by copying and pasting (like “iphone,x”) and it’s considered a single synonym. However visually it shows as two synonyms.
* back button doesn’t work
* we should put spaces after the commas in the list view for the synonyms
* after entering a synonym, if you just hit enter instead of clicking Publish, the set doesn’t save
* let’s get rid of this description text: “Type a comma or press enter to input an alias”
* the word you’re typing disappears if you lose focus before hitting enter/comma