### PR TITLE
LSP-78501: Spell checking does not always give a suggestion when number of results are below the threshold

### DIFF
--- a/modules/apps/portal-search-elasticsearch6/portal-search-elasticsearch6-impl/src/main/java/com/liferay/portal/search/elasticsearch6/internal/ElasticsearchQuerySuggester.java
+++ b/modules/apps/portal-search-elasticsearch6/portal-search-elasticsearch6-impl/src/main/java/com/liferay/portal/search/elasticsearch6/internal/ElasticsearchQuerySuggester.java
@@ -196,6 +196,7 @@ public class ElasticsearchQuerySuggester implements QuerySuggester {
 			_SPELL_CHECK_REQUEST_NAME, field, searchContext.getKeywords());
 
 		termSuggester.setSize(max);
+		termSuggester.setSuggestMode(Suggester.SuggestMode.ALWAYS);
 
 		return termSuggester;
 	}

--- a/modules/apps/portal-search-solr7/portal-search-solr7-impl/src/main/java/com/liferay/portal/search/solr7/internal/SolrQuerySuggester.java
+++ b/modules/apps/portal-search-solr7/portal-search-solr7-impl/src/main/java/com/liferay/portal/search/solr7/internal/SolrQuerySuggester.java
@@ -384,7 +384,7 @@ public class SolrQuerySuggester implements QuerySuggester {
 					solrDocument.get(Field.PRIORITY));
 
 				if (suggestion.equals(input)) {
-					weight = _INFINITE_WEIGHT;
+					weight = 0F;
 				}
 				else {
 					String inputLowerCase = StringUtil.toLowerCase(input);
@@ -425,8 +425,6 @@ public class SolrQuerySuggester implements QuerySuggester {
 	}
 
 	private static final long _GLOBAL_GROUP_ID = 0;
-
-	private static final float _INFINITE_WEIGHT = 100F;
 
 	private static final int _MAX_QUERY_RESULTS = 500;
 

--- a/modules/apps/portal-search/portal-search-test-util/src/main/java/com/liferay/portal/search/test/util/spellcheck/BaseSpellCheckTestCase.java
+++ b/modules/apps/portal-search/portal-search-test-util/src/main/java/com/liferay/portal/search/test/util/spellcheck/BaseSpellCheckTestCase.java
@@ -109,6 +109,14 @@ public abstract class BaseSpellCheckTestCase extends BaseIndexingTestCase {
 	}
 
 	@Test
+	public void testSpellCheckAlways() throws Exception {
+		indexSpellCheckWord("index");
+		indexSpellCheckWord("indxe");
+
+		assertSpellCheck("indxe", "index");
+	}
+
+	@Test
 	public void testSpellCheckMap() throws Exception {
 		indexSpellCheckWord("liferay");
 


### PR DESCRIPTION
https://issues.liferay.com/browse/LPS-78501